### PR TITLE
Add initial documentation structure

### DIFF
--- a/docs/contributing/changelog.md
+++ b/docs/contributing/changelog.md
@@ -1,0 +1,4 @@
+# Changelog
+
+# The End
+

--- a/docs/contributing/compatibility.md
+++ b/docs/contributing/compatibility.md
@@ -1,0 +1,4 @@
+# Compatibility
+
+# The End
+

--- a/docs/contributing/guide.md
+++ b/docs/contributing/guide.md
@@ -1,0 +1,4 @@
+# Guide
+
+# The End
+

--- a/docs/examples/demo-app.md
+++ b/docs/examples/demo-app.md
@@ -1,0 +1,4 @@
+# Demo App
+
+# The End
+

--- a/docs/explanations/architecture.md
+++ b/docs/explanations/architecture.md
@@ -1,0 +1,4 @@
+# Architecture
+
+# The End
+

--- a/docs/explanations/forms-ux.md
+++ b/docs/explanations/forms-ux.md
@@ -1,0 +1,4 @@
+# Forms Ux
+
+# The End
+

--- a/docs/explanations/operations.md
+++ b/docs/explanations/operations.md
@@ -1,0 +1,4 @@
+# Operations
+
+# The End
+

--- a/docs/explanations/performance.md
+++ b/docs/explanations/performance.md
@@ -1,0 +1,4 @@
+# Performance
+
+# The End
+

--- a/docs/explanations/security.md
+++ b/docs/explanations/security.md
@@ -1,0 +1,4 @@
+# Security
+
+# The End
+

--- a/docs/getting-started/first-login.md
+++ b/docs/getting-started/first-login.md
@@ -1,0 +1,4 @@
+# First Login
+
+# The End
+

--- a/docs/getting-started/first-model.md
+++ b/docs/getting-started/first-model.md
@@ -1,0 +1,4 @@
+# First Model
+
+# The End
+

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -1,0 +1,4 @@
+# Install
+
+# The End
+

--- a/docs/how-to/bulk-actions.md
+++ b/docs/how-to/bulk-actions.md
@@ -1,0 +1,4 @@
+# Bulk Actions
+
+# The End
+

--- a/docs/how-to/custom-view.md
+++ b/docs/how-to/custom-view.md
@@ -1,0 +1,4 @@
+# Custom View
+
+# The End
+

--- a/docs/how-to/custom-widget.md
+++ b/docs/how-to/custom-widget.md
@@ -1,0 +1,4 @@
+# Custom Widget
+
+# The End
+

--- a/docs/how-to/customize-list.md
+++ b/docs/how-to/customize-list.md
@@ -1,0 +1,4 @@
+# Customize List
+
+# The End
+

--- a/docs/how-to/deploy-reverse-proxy.md
+++ b/docs/how-to/deploy-reverse-proxy.md
@@ -1,0 +1,4 @@
+# Deploy Reverse Proxy
+
+# The End
+

--- a/docs/how-to/file-upload.md
+++ b/docs/how-to/file-upload.md
@@ -1,0 +1,4 @@
+# File Upload
+
+# The End
+

--- a/docs/how-to/filters.md
+++ b/docs/how-to/filters.md
@@ -1,0 +1,4 @@
+# Filters
+
+# The End
+

--- a/docs/how-to/fk-autocomplete.md
+++ b/docs/how-to/fk-autocomplete.md
@@ -1,0 +1,4 @@
+# Fk Autocomplete
+
+# The End
+

--- a/docs/how-to/override-templates.md
+++ b/docs/how-to/override-templates.md
@@ -1,0 +1,4 @@
+# Override Templates
+
+# The End
+

--- a/docs/how-to/permissions.md
+++ b/docs/how-to/permissions.md
@@ -1,0 +1,4 @@
+# Permissions
+
+# The End
+

--- a/docs/how-to/register-model.md
+++ b/docs/how-to/register-model.md
@@ -1,0 +1,4 @@
+# Register Model
+
+# The End
+

--- a/docs/how-to/search-ordering.md
+++ b/docs/how-to/search-ordering.md
@@ -1,0 +1,4 @@
+# Search Ordering
+
+# The End
+

--- a/docs/how-to/testing.md
+++ b/docs/how-to/testing.md
@@ -1,0 +1,4 @@
+# Testing
+
+# The End
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,52 @@
+# Overview
+
+## Getting Started
+- [Install](getting-started/install.md)
+- [First Login](getting-started/first-login.md)
+- [First Model](getting-started/first-model.md)
+
+## How-To
+- [Register Model](how-to/register-model.md)
+- [Customize List](how-to/customize-list.md)
+- [Search & Ordering](how-to/search-ordering.md)
+- [Filters](how-to/filters.md)
+- [FK Autocomplete](how-to/fk-autocomplete.md)
+- [File Upload](how-to/file-upload.md)
+- [Permissions](how-to/permissions.md)
+- [Bulk Actions](how-to/bulk-actions.md)
+- [Custom Widget](how-to/custom-widget.md)
+- [Custom View](how-to/custom-view.md)
+- [Override Templates](how-to/override-templates.md)
+- [Deploy Reverse Proxy](how-to/deploy-reverse-proxy.md)
+- [Testing](how-to/testing.md)
+
+## Reference
+- [AdminSite](reference/adminsite.md)
+- [ModelAdmin](reference/modeladmin.md)
+- [Adapters](reference/adapters.md)
+- [Widgets](reference/widgets.md)
+- [Routing](reference/routing.md)
+- [Endpoints](reference/endpoints.md)
+- [Permissions & Auth](reference/permissions-auth.md)
+- [Settings](reference/settings.md)
+- [Templates & Assets](reference/templates-assets.md)
+- [Errors & Logging](reference/errors-logging.md)
+- [Index by Symbols](reference/index-by-symbols.md)
+
+## Explanations
+- [Architecture](explanations/architecture.md)
+- [Security](explanations/security.md)
+- [Performance](explanations/performance.md)
+- [Forms & UX](explanations/forms-ux.md)
+- [Operations](explanations/operations.md)
+
+## Contributing
+- [Guide](contributing/guide.md)
+- [Changelog](contributing/changelog.md)
+- [Compatibility](contributing/compatibility.md)
+
+## Examples
+- [Demo App](examples/demo-app.md)
+
+# The End
 

--- a/docs/reference/adapters.md
+++ b/docs/reference/adapters.md
@@ -1,0 +1,4 @@
+# Adapters
+
+# The End
+

--- a/docs/reference/adminsite.md
+++ b/docs/reference/adminsite.md
@@ -1,0 +1,4 @@
+# Adminsite
+
+# The End
+

--- a/docs/reference/endpoints.md
+++ b/docs/reference/endpoints.md
@@ -1,0 +1,4 @@
+# Endpoints
+
+# The End
+

--- a/docs/reference/errors-logging.md
+++ b/docs/reference/errors-logging.md
@@ -1,0 +1,4 @@
+# Errors Logging
+
+# The End
+

--- a/docs/reference/index-by-symbols.md
+++ b/docs/reference/index-by-symbols.md
@@ -1,0 +1,4 @@
+# Index By Symbols
+
+# The End
+

--- a/docs/reference/modeladmin.md
+++ b/docs/reference/modeladmin.md
@@ -1,0 +1,4 @@
+# Modeladmin
+
+# The End
+

--- a/docs/reference/permissions-auth.md
+++ b/docs/reference/permissions-auth.md
@@ -1,0 +1,4 @@
+# Permissions Auth
+
+# The End
+

--- a/docs/reference/routing.md
+++ b/docs/reference/routing.md
@@ -1,0 +1,4 @@
+# Routing
+
+# The End
+

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -1,0 +1,4 @@
+# Settings
+
+# The End
+

--- a/docs/reference/templates-assets.md
+++ b/docs/reference/templates-assets.md
@@ -1,0 +1,4 @@
+# Templates Assets
+
+# The End
+

--- a/docs/reference/widgets.md
+++ b/docs/reference/widgets.md
@@ -1,0 +1,4 @@
+# Widgets
+
+# The End
+


### PR DESCRIPTION
## Summary
- scaffold documentation directory tree with placeholder pages
- add navigation overview linking to all sections

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acb6ad6c1883308d9e94c9b8905ca6