### PR TITLE
Add demo note model and admin registration

### DIFF
--- a/freeadmin/example/apps/demo/admin.py
+++ b/freeadmin/example/apps/demo/admin.py
@@ -1,3 +1,36 @@
+# -*- coding: utf-8 -*-
 """
-Place your admin classes for your ORM models here
+admin
+
+Administrative configuration for the FreeAdmin demo models.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
 """
+
+from __future__ import annotations
+
+from freeadmin.core.models import ModelAdmin
+from freeadmin.hub import admin_site
+
+from .models import DemoNote
+
+
+class DemoNoteAdmin(ModelAdmin):
+    """Expose :class:`DemoNote` records to the administration interface."""
+
+    label = "Demo Notes"
+    label_singular = "Demo Note"
+    list_display = ("id", "title", "created_at")
+    search_fields = ("title", "content")
+    ordering = ("-created_at",)
+
+
+admin_site.register(app="demo", model=DemoNote, admin_cls=DemoNoteAdmin, icon="bi-journal-text")
+
+
+__all__ = ["DemoNoteAdmin"]
+
+
+# The End

--- a/freeadmin/example/apps/demo/app.py
+++ b/freeadmin/example/apps/demo/app.py
@@ -15,6 +15,7 @@ class DemoConfig(ExampleAppConfig):
 
     app_label = "demo"
     name = "freeadmin.example.apps.demo"
+    models = ("freeadmin.example.apps.demo.models",)
 
     def __init__(self) -> None:
         """Instantiate helpers required for the demo showcase."""

--- a/freeadmin/example/apps/demo/models.py
+++ b/freeadmin/example/apps/demo/models.py
@@ -1,3 +1,40 @@
+# -*- coding: utf-8 -*-
 """
-Place your ORM models here
+models
+
+Tortoise ORM models that back the FreeAdmin demo application.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
 """
+
+from __future__ import annotations
+
+from tortoise import fields
+from tortoise.models import Model
+
+
+class DemoNote(Model):
+    """Represent a short note managed through the demo administration UI."""
+
+    id = fields.IntField(pk=True)
+    title = fields.CharField(max_length=120)
+    content = fields.TextField()
+    created_at = fields.DatetimeField(auto_now_add=True)
+
+    class Meta:
+        table = "demo_notes"
+
+    def __str__(self) -> str:
+        """Return a concise textual representation of the note."""
+
+        if self.created_at:
+            return f"{self.title} ({self.created_at:%Y-%m-%d})"
+        return self.title
+
+
+__all__ = ["DemoNote"]
+
+
+# The End

--- a/freeadmin/example/config/settings.py
+++ b/freeadmin/example/config/settings.py
@@ -12,11 +12,15 @@ Email: timurkady@yandex.com
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import ClassVar
 
 
 @dataclass(slots=True)
 class ExampleSettings:
     """Store runtime metadata for the FreeAdmin example project."""
+
+    ADMIN_PATH: ClassVar[str] = "/panel"
+    INSTALLED_APPS: ClassVar[list[str]] = ["freeadmin.example.apps.demo"]
 
     project_name: str = "FreeAdmin Example"
     session_secret: str = "change-me"
@@ -27,6 +31,8 @@ class ExampleSettings:
         return {
             "project_name": self.project_name,
             "session_secret": self.session_secret,
+            "admin_path": self.ADMIN_PATH,
+            "installed_apps": ", ".join(self.INSTALLED_APPS),
         }
 
 


### PR DESCRIPTION
## Summary
- declare constants for the demo admin path and installed apps in the example settings
- implement a DemoNote Tortoise ORM model with an accompanying ModelAdmin configuration
- expose the demo models module through the demo app configuration for discovery

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ea9af6104c8330b9a17df9333f6bb1