### PR TITLE
Document configuration initialization routines

### DIFF
--- a/freeadmin/conf.py
+++ b/freeadmin/conf.py
@@ -171,6 +171,8 @@ class SettingsManager:
     """Central storage for the active ``FreeAdminSettings`` instance."""
 
     def __init__(self, initial: FreeAdminSettings | None = None) -> None:
+        """Prepare storage with an optional preconfigured ``initial`` settings."""
+
         self._lock = RLock()
         self._settings = initial
         self._callbacks: list[Callable[[FreeAdminSettings], None]] = []

--- a/freeadmin/core/registry.py
+++ b/freeadmin/core/registry.py
@@ -72,6 +72,8 @@ class PageRegistry:
     """Store registered pages and model admin view entries."""
 
     def __init__(self) -> None:
+        """Initialize empty collections for pages, views, and cards."""
+
         self.page_list: List[AdminPage] = []
         self.view_entries: List[ViewEntry] = []
         self.card_entries: Dict[str, CardEntry] = {}

--- a/freeadmin/core/settings/config.py
+++ b/freeadmin/core/settings/config.py
@@ -11,8 +11,8 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 
-from typing import Any
 import logging
+from typing import Any
 
 from .defaults import DEFAULT_SETTINGS
 from .keys import SettingsKey
@@ -31,10 +31,14 @@ class SystemConfig:
     """
 
     def __init__(self) -> None:
+        """Initialize an empty in-memory cache for system settings."""
+
         self._cache: dict[str, Any] = {}
 
     @property
-    def adapter(self):
+    def adapter(self) -> Any:
+        """Return the active data adapter responsible for persistence."""
+
         from ...boot import admin as boot_admin
 
         return boot_admin.adapter

--- a/freeadmin/provider.py
+++ b/freeadmin/provider.py
@@ -31,6 +31,8 @@ class TemplateProvider:
         static_dir: str | Path,
         settings: FreeAdminSettings | None = None,
     ) -> None:
+        """Store template and static paths together with active settings."""
+
         self.templates_dir = str(templates_dir)
         self.static_dir = str(static_dir)
         self._settings = settings or current_settings()


### PR DESCRIPTION
## Summary
- add docstrings to configuration and registry initializers to clarify responsibilities
- reorder system config imports to follow standard library conventions
- document template provider setup to better explain cached settings usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea9b5c55308330af2c4978769a93b1