### PR TITLE
Add demo note model and settings metadata

### DIFF
--- a/example/apps/demo/admin.py
+++ b/example/apps/demo/admin.py
@@ -1,3 +1,26 @@
 """
 Place your admin classes for your ORM models here
 """
+
+from __future__ import annotations
+
+from freeadmin.core.models import ModelAdmin
+from freeadmin.hub import admin_site
+
+from .models import DemoNote
+
+
+class DemoNoteAdmin(ModelAdmin):
+    """Expose DemoNote instances through the administration interface."""
+
+    label = "Demo notes"
+    list_display = ("id", "title", "created_at")
+    search_fields = ("title", "body")
+
+
+admin_site.register(app="demo", model=DemoNote, admin_cls=DemoNoteAdmin)
+
+
+__all__ = ["DemoNoteAdmin"]
+
+# The End

--- a/example/apps/demo/models.py
+++ b/example/apps/demo/models.py
@@ -1,3 +1,30 @@
 """
 Place your ORM models here
 """
+
+from __future__ import annotations
+
+from tortoise import fields
+from tortoise.models import Model
+
+
+class DemoNote(Model):
+    """Represent a short textual note stored for the demo panel."""
+
+    id = fields.IntField(pk=True)
+    title = fields.CharField(max_length=120)
+    body = fields.TextField(null=True)
+    created_at = fields.DatetimeField(auto_now_add=True)
+
+    class Meta:
+        table = "demo_note"
+
+    def __str__(self) -> str:
+        """Return the note title for human-friendly identification."""
+
+        return self.title
+
+
+__all__ = ["DemoNote"]
+
+# The End

--- a/example/config/settings.py
+++ b/example/config/settings.py
@@ -12,12 +12,17 @@ Email: timurkady@yandex.com
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import ClassVar
 
 
 @dataclass(slots=True)
 class ExampleSettings:
     """Store runtime metadata for the FreeAdmin example project."""
 
+    ADMIN_PATH: ClassVar[str] = "/panel"
+    INSTALLED_APPS: ClassVar[list[str]] = [
+        "example.apps.demo",
+    ]
     project_name: str = "FreeAdmin Example"
     session_secret: str = "change-me"
 
@@ -27,6 +32,8 @@ class ExampleSettings:
         return {
             "project_name": self.project_name,
             "session_secret": self.session_secret,
+            "admin_path": self.ADMIN_PATH,
+            "installed_apps": ",".join(self.INSTALLED_APPS),
         }
 
 


### PR DESCRIPTION
## Summary
- define admin path and installed apps metadata on the example settings object
- add a simple DemoNote tortoise model for the demo application
- expose the DemoNote model through a DemoNoteAdmin registration

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'freeadmin'; ModuleNotFoundError: No module named 'lxml')*


------
https://chatgpt.com/codex/tasks/task_e_68ea9d3902548330b71ac5ba742e479d