### PR TITLE
Remove Redis runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "starlette>=0.37,<0.38",
     "jinja2>=3.1,<4.0",
     "itsdangerous>=2.1,<3.0",
-    "redis>=5.0,<6.0",
     "tortoise-orm>=0.20,<0.22",
     "python-multipart>=0.0.7,<0.0.9",
     "pydantic>=1.10,<3.0",
@@ -24,12 +23,13 @@ dependencies = [
     "lxml>=4.9,<6.0",
 ]
 
-[project.scripts]
-free-admin = "freeadmin.cli:cli"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Framework :: FastAPI",
 ]
+
+[project.scripts]
+free-admin = "freeadmin.cli:cli"
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
## Summary
- remove the Redis requirement from the project dependencies and keep classifiers with the project metadata

## Testing
- python -m build

------
https://chatgpt.com/codex/tasks/task_e_68eabaa9b52c833082e9c6070c51250e