### PR TITLE
Update project metadata in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,14 @@ version = "0.1.0"
 description = "Reusable administrative interface extracted from Cortex."
 authors = [{ name = "Timur Kady", email = "timurkady@yandex.com" }]
 readme = "README.md"
+license = "AGPL-3.0-or-later"
 requires-python = ">=3.11"
+license-files = ["LICENSE"]
+keywords = ["fastapi", "admin", "tortoise-orm", "dashboard"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Framework :: FastAPI",
+]
 dependencies = [
     "click>=8.1,<9.0",
     "fastapi>=0.110,<0.112",
@@ -26,10 +33,11 @@ dependencies = [
 
 [project.scripts]
 free-admin = "freeadmin.cli:cli"
-classifiers = [
-    "Programming Language :: Python :: 3",
-    "Framework :: FastAPI",
-]
+
+[project.urls]
+Homepage = "https://github.com/TimurKady/free-admin"
+Source = "https://github.com/TimurKady/free-admin"
+Documentation = "https://github.com/TimurKady/free-admin#readme"
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
## Summary
- move project classifiers into the main [project] table and add keywords, license, and URL metadata
- ensure the AGPL license file is referenced for packaging metadata

## Testing
- python -m build
- python -m venv .venv-buildtest && source .venv-buildtest/bin/activate && python -m pip install --upgrade pip && python -m pip install dist/freeadmin-*.whl

------
https://chatgpt.com/codex/tasks/task_e_68eaba9aac288330b3115d0095cc4b22