### PR TITLE
Add Twine validation to release workflow and checklist

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - run: python -m pip install --upgrade pip build
+      - run: python -m pip install --upgrade pip build twine
       - run: python -m build
+      - run: python -m twine check dist/*
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/docs/release-review.md
+++ b/docs/release-review.md
@@ -23,3 +23,8 @@ If a vendor is updated, replace the assets and refresh the license file at the s
   - Source archive: `dist/freeadmin-0.1.0.tar.gz` ≈ 6.2 MB.
 
 These numbers provide a baseline for future reviews. Investigate any large deltas and consider trimming optional Ace modes or JSONEditor test fixtures if distribution size becomes an issue.
+
+## Distribution validation
+
+- Build the distributions via `python -m build` and immediately run `python -m twine check dist/*`.
+- Capture and fix any rendering issues reported by Twine (typically `Project-URL` or README formatting problems) before tagging the release.


### PR DESCRIPTION
## Summary
- install Twine in the publish workflow and add a validation step after building distributions
- document the Twine check alongside the existing release review so manual releases capture README rendering issues

## Testing
- python -m build
- python -m twine check dist/*

------
https://chatgpt.com/codex/tasks/task_e_68eacffabd6c83309adb103a9c5ce645