### PR TITLE
Install Twine before verifying build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Build distribution
         if: steps.backend.outputs.has_backend == 'true'
         run: |
-          python -m pip install --upgrade build
+          python -m pip install --upgrade build twine
           python -m build
 
       - name: Verify built artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
 
+      - name: Install test tooling
+        run: python -m pip install pytest
+
       - name: Run test suite
         run: |
           if [ -f pyproject.toml ] || [ -f setup.cfg ] || [ -f setup.py ]; then


### PR DESCRIPTION
## Summary
- install Twine alongside the build backend tooling in the packaging step so artifact verification succeeds

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68ead58ef2a48330a421ea165a90eb2a