### PR TITLE
Narrow package data globs to static assets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,6 @@ include = [
     "MANIFEST.in",
     "pyproject.toml",
 ]
+
+[tool.setuptools.package-data]
+freeadmin = ["static/**/*", "templates/**/*"]


### PR DESCRIPTION
## Summary
- replace the setuptools package-data catch-all glob with static and template specific patterns to avoid including code modules in the wheel

## Testing
- python -m build

------
https://chatgpt.com/codex/tasks/task_e_68eb6909507483308761af0db0d9826d