### PR TITLE
Add Python version and license classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,10 @@ license-files = ["LICENSE"]
 keywords = ["fastapi", "admin", "tortoise-orm", "dashboard"]
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Framework :: FastAPI",
+    "License :: OSI Approved :: GNU Affero General Public License v3",
 ]
 dependencies = [
     "click>=8.1,<9.0",


### PR DESCRIPTION
## Summary
- declare support for Python 3.11 and 3.12 in the project classifiers
- document the AGPLv3 license through the trove classifier

## Testing
- python -m build

------
https://chatgpt.com/codex/tasks/task_e_68eb69e56fd88330b5e6eb411338f707