### PR TITLE
Include commercial license file in built artifacts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ pythonpath = ["."]
 
 [tool.hatch.build.targets.wheel]
 packages = ["freeadmin"]
+[tool.hatch.build.targets.wheel.force-include]
+"COMMERCIAL-LICENSE.md" = "COMMERCIAL-LICENSE.md"
 
 [tool.hatch.build.targets.sdist]
 include = [
@@ -54,6 +56,7 @@ include = [
     "example",
     "tests",
     "LICENSE",
+    "COMMERCIAL-LICENSE.md",
     "README.md",
     "MANIFEST.in",
     "pyproject.toml",


### PR DESCRIPTION
## Summary
- add the commercial license file to the source distribution include list
- force-include the commercial license file in wheel builds so it is shipped with binary artifacts

## Testing
- python -m build

------
https://chatgpt.com/codex/tasks/task_e_68eb7140cd5083309b73d23fc1f0bef6