### PR TITLE
Update project license metadata to reference LICENSE file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Reusable administrative interface extracted from Cortex."
 authors = [{ name = "Timur Kady", email = "timurkady@yandex.com" }]
 readme = "README.md"
-license = { text = "AGPL-3.0-or-later" }
+license = { file = "LICENSE" }
 requires-python = ">=3.11"
 license-files = ["LICENSE"]
 keywords = ["fastapi", "admin", "tortoise-orm", "dashboard"]


### PR DESCRIPTION
## Summary
- update the project license declaration to reference the LICENSE file instead of embedding the text

## Testing
- python -m build

------
https://chatgpt.com/codex/tasks/task_e_68eb7244037883308e512892cbd31089