### PR TITLE
Remove lxml runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "pydantic>=1.10,<3.0",
     "pyjwt>=2.8,<3.0",
     "openpyxl>=3.1,<4.0",
-    "lxml>=4.9,<6.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- remove the lxml requirement from the project metadata so it is no longer a runtime dependency

## Testing
- python -m build
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eb729ba5288330928b9eb32d107e79