### PR TITLE
Fix documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Then open [http://127.0.0.1:8000/admin](http://127.0.0.1:8000/admin).
 
 ## Documentation
 
-Commıng soon
+See the [Documentation](https://github.com/TimurKady/freeadmin/blob/main/docs/index.md).
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary
- replace the relative documentation link in the README with an absolute GitHub URL so it renders correctly on PyPI

## Testing
- python -m build
- python -m twine check dist/*

------
https://chatgpt.com/codex/tasks/task_e_68eb73486cf48330bb87671fecf8ca06