### PR TITLE
Expose adapter-backed admin models through package exports

### DIFF
--- a/freeadmin/models/__init__.py
+++ b/freeadmin/models/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-__init__
+"""__init__
 
 Single point of connection of Admin Models.
 
@@ -10,34 +9,21 @@ Email: timurkady@yandex.com
 """
 
 from __future__ import annotations
-from typing import List
 
-from ..boot import admin as boot_admin
-from .autodiscoverer import ModelAutoDiscoverer
 from .choices import IntChoices, IntegerChoices, StrChoices, TextChoices  # noqa: F401
+from .content_type import AdminContentType  # noqa: F401
+from .groups import AdminGroup, AdminGroupPermission  # noqa: F401
+from .setting import SystemSetting  # noqa: F401
+from .users import AdminUser, AdminUserPermission  # noqa: F401
+from ._registry import (  # noqa: F401
+    ModelBase,
+    PermAction,
+    SettingValueType,
+    adapter,
+    __all__,
+    __models__,
+)
 
-try:
-    adapter = boot_admin.adapter
-    ModelBase = adapter.Model
-    PermAction = adapter.perm_action
-    SettingValueType = adapter.setting_value_type
-    _discoverer = ModelAutoDiscoverer(ModelBase)
-    __models__: List[type[ModelBase]] = _discoverer.models
-    __all__ = [
-        "StrChoices",
-        "IntChoices",
-        "TextChoices",
-        "IntegerChoices",
-        "PermAction",
-        "SettingValueType",
-    ]
-except ModuleNotFoundError:  # pragma: no cover - during adapter bootstrap
-    adapter = None  # type: ignore
-    ModelBase = object  # type: ignore
-    PermAction = None  # type: ignore
-    SettingValueType = None  # type: ignore
-    __models__: List[type[ModelBase]] = []
-    __all__ = ["StrChoices", "IntChoices", "TextChoices", "IntegerChoices"]
 
 # The End
 

--- a/freeadmin/models/_registry.py
+++ b/freeadmin/models/_registry.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""_registry
+
+Adapter-backed model registry used by :mod:`freeadmin.models`.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Sequence, Type
+
+from ..boot import admin as boot_admin
+from .autodiscoverer import ModelAutoDiscoverer
+
+
+class ModelRegistry:
+    """Encapsulate discovery and export of adapter-backed admin models."""
+
+    def __init__(self) -> None:
+        """Load adapter-specific metadata required for admin models."""
+
+        try:
+            adapter = boot_admin.adapter
+        except ModuleNotFoundError:  # pragma: no cover - during adapter bootstrap
+            self._adapter: Optional[object] = None
+            self._model_base: Type[object] = object
+            self._perm_action: Optional[object] = None
+            self._setting_value_type: Optional[object] = None
+            self._models: List[Type[object]] = []
+        else:
+            self._adapter = adapter
+            self._model_base = adapter.Model
+            self._perm_action = adapter.perm_action
+            self._setting_value_type = adapter.setting_value_type
+            discoverer = ModelAutoDiscoverer(self._model_base)
+            self._models = discoverer.models
+
+    @property
+    def adapter(self) -> Optional[object]:
+        """Return the active admin adapter or ``None`` when unavailable."""
+
+        return self._adapter
+
+    @property
+    def model_base(self) -> Type[object]:
+        """Return the base model class provided by the adapter."""
+
+        return self._model_base
+
+    @property
+    def perm_action(self) -> Optional[object]:
+        """Return the adapter-specific permission action enumeration."""
+
+        return self._perm_action
+
+    @property
+    def setting_value_type(self) -> Optional[object]:
+        """Return the enumeration describing supported setting value types."""
+
+        return self._setting_value_type
+
+    @property
+    def models(self) -> Sequence[Type[object]]:
+        """Return the lazily discovered set of admin models."""
+
+        return tuple(self._models)
+
+    def export_names(self) -> List[str]:
+        """Return the module export list used by :mod:`freeadmin.models`."""
+
+        base_exports = [
+            "StrChoices",
+            "IntChoices",
+            "TextChoices",
+            "IntegerChoices",
+            "PermAction",
+            "SettingValueType",
+        ]
+        dynamic_exports = [model.__name__ for model in self._models]
+        return base_exports + dynamic_exports
+
+
+registry = ModelRegistry()
+
+adapter = registry.adapter
+ModelBase = registry.model_base
+PermAction = registry.perm_action
+SettingValueType = registry.setting_value_type
+__models__ = list(registry.models)
+__all__ = registry.export_names()
+
+
+# The End
+

--- a/freeadmin/models/content_type.py
+++ b/freeadmin/models/content_type.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""content_type
+
+Adapter-backed admin content type model exports.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from __future__ import annotations
+
+from ..boot import admin as boot_admin
+
+try:
+    AdminContentType = boot_admin.adapter.content_type_model
+except ModuleNotFoundError:  # pragma: no cover - during adapter bootstrap
+    AdminContentType = object  # type: ignore[assignment]
+
+
+# The End
+

--- a/freeadmin/models/groups.py
+++ b/freeadmin/models/groups.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""groups
+
+Adapter-backed admin group model exports.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from __future__ import annotations
+
+from ..boot import admin as boot_admin
+
+try:
+    AdminGroup = boot_admin.adapter.group_model
+    AdminGroupPermission = boot_admin.adapter.group_permission_model
+except ModuleNotFoundError:  # pragma: no cover - during adapter bootstrap
+    AdminGroup = object  # type: ignore[assignment]
+    AdminGroupPermission = object  # type: ignore[assignment]
+
+
+# The End
+

--- a/freeadmin/models/setting.py
+++ b/freeadmin/models/setting.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""setting
+
+Adapter-backed admin system setting model exports.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from __future__ import annotations
+
+from ..boot import admin as boot_admin
+
+try:
+    SystemSetting = boot_admin.adapter.system_setting_model
+except ModuleNotFoundError:  # pragma: no cover - during adapter bootstrap
+    SystemSetting = object  # type: ignore[assignment]
+
+
+# The End
+

--- a/freeadmin/models/users.py
+++ b/freeadmin/models/users.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""users
+
+Adapter-backed admin user model exports.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from __future__ import annotations
+
+from ..boot import admin as boot_admin
+
+try:
+    AdminUser = boot_admin.adapter.user_model
+    AdminUserPermission = boot_admin.adapter.user_permission_model
+except ModuleNotFoundError:  # pragma: no cover - during adapter bootstrap
+    AdminUser = object  # type: ignore[assignment]
+    AdminUserPermission = object  # type: ignore[assignment]
+
+
+# The End
+

--- a/tests/test_models_import.py
+++ b/tests/test_models_import.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""test_models_import
+
+Smoke tests for ``freeadmin.models`` public exports.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from __future__ import annotations
+
+from freeadmin import models
+
+
+class TestModelsImport:
+    """Smoke test suite validating ``freeadmin.models`` exports."""
+
+    def test_adapter_models_are_reachable(self) -> None:
+        """Ensure adapter-backed admin models are exposed on the package."""
+
+        assert getattr(models, "AdminUser", None) is not None
+        assert getattr(models, "AdminUserPermission", None) is not None
+        assert getattr(models, "AdminGroup", None) is not None
+        assert getattr(models, "AdminGroupPermission", None) is not None
+        assert getattr(models, "AdminContentType", None) is not None
+        assert getattr(models, "SystemSetting", None) is not None
+
+
+# The End
+


### PR DESCRIPTION
## Summary
- add dedicated adapter-backed model modules that re-export boot adapter classes
- centralize model registry logic to expose adapter metadata and expand __all__ exports
- cover the package import surface with a smoke test ensuring admin models are reachable

## Testing
- pytest tests/test_models_import.py

------
https://chatgpt.com/codex/tasks/task_e_68ebd764ab048330965d15c8b8cf1596