### PR TITLE
docs: refresh models admin guide

### DIFF
--- a/docs/models-and-admin-models.md
+++ b/docs/models-and-admin-models.md
@@ -1,25 +1,37 @@
 # Models and Admin Models
 
-This section explains how to define database models and configure their administrative interfaces using `ModelAdmin` and `InlineAdmin`.
+This guide walks through the journey from defining database models to exposing
+them inside the FreeAdmin interface. The focus is on providing context-rich
+explanations so you can understand **why** each piece matters before you copy a
+line of code.
 
-FreeAdmin separates **data definition** (models) from **presentation logic** (admin classes).  
-You define your models using your ORM (e.g. Tortoise ORM), and then describe how they appear and behave in the admin interface.
+FreeAdmin keeps a clean separation between two layers:
 
+1. **ORM models** describe your data schema and business rules.
+2. **Admin descriptors** (`ModelAdmin` and `InlineModelAdmin`) describe how
+   those models are presented, searched, filtered, and mutated inside the
+   administration UI.
 
-## Defining a Model
+Because the admin layer is thin, you can bring your own asynchronous ORM. The
+examples below use Tortoise ORM, but the APIs highlighted here mirror the
+adapter contracts implemented in `freeadmin.core.base.BaseModelAdmin`.
 
-Models describe your data structure — tables, fields, and relations.  
-FreeAdmin supports any ORM that provides metadata and async CRUD operations.  
-The examples below use **Tortoise ORM**.
+---
 
-Example:
+## Defining an ORM model
+
+You start by declaring ordinary ORM models. The admin site only requires that
+the adapter can introspect fields and execute async CRUD operations.
 
 ```python
-# apps/products/models.py
+# apps/catalog/models.py
 from tortoise import fields
 from tortoise.models import Model
 
+
 class Product(Model):
+    """Minimal Tortoise model used throughout the examples below."""
+
     id = fields.IntField(pk=True)
     name = fields.CharField(max_length=200)
     price = fields.DecimalField(max_digits=10, decimal_places=2)
@@ -27,199 +39,274 @@ class Product(Model):
     created_at = fields.DatetimeField(auto_now_add=True)
 
     class Meta:
-        table = "product"
+        table = "catalog_product"
         ordering = ["name"]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
-````
-
-> **Tip:**
-> Every model should have a `Meta` class with `table` name and default `ordering`.
-> Use `__str__` to define how the object appears in dropdowns and relation fields.
-
-
-## Registering Models in the Admin
-
-Once the model is defined, you must **register** it with FreeAdmin.
-
-Each app has its own `app.py` file that defines an `AppConfig`.
-Inside `ready()`, register your model and its admin definition:
-
-```python
-# apps/products/app.py
-from freeadmin import AppConfig
-from .models import Product
-from .admin import ProductAdmin
-
-class ProductsConfig(AppConfig):
-    app_label = "products"
-    name = "apps.products"
-
-    def ready(self):
-        self.register(Product, ProductAdmin)
-
-default = ProductsConfig()
 ```
 
-## Creating a ModelAdmin
-
-`ModelAdmin` controls how a model appears in the admin interface:
-columns, filters, search fields, ordering, and actions.
-
-Example:
-
-```python
-# apps/products/admin.py
-from freeadmin import ModelAdmin
-from .models import Product
-
-class ProductAdmin(ModelAdmin):
-    list_display = ["name", "price", "available"]
-    search_fields = ["name"]
-    list_filter = ["available"]
-    ordering = ["name"]
-    per_page = 25
-```
-
-| Attribute           | Type      | Description                    |
-| ------------------- | --------- | ------------------------------ |
-| **`list_display`**  | list[str] | Columns shown in the list view |
-| **`search_fields`** | list[str] | Fields used for search         |
-| **`list_filter`**   | list[str] | Sidebar filters                |
-| **`ordering`**      | list[str] | Default order                  |
-| **`per_page`**      | int       | Pagination limit               |
+> **Narrative tip.** Choose descriptive `Meta.table` values and implement
+> `__str__`. FreeAdmin reuses them when it renders relation widgets, inline
+> badges, and selection lists.
 
 ---
 
-## InlineAdmin
+## Registering models with the admin site
 
-`InlineAdmin` lets you edit related objects directly inside the parent form.
-
-Example:
+Once the model exists you hook it into the global admin site. The admin hub is
+exposed through `freeadmin.hub.admin_site`. Registration wires together the
+model class, its admin descriptor, menu metadata, and the adapter used to talk
+to your database.
 
 ```python
-# apps/products/admin.py
-from freeadmin import InlineAdmin
-from .models import ProductImage
+# apps/catalog/admin.py
+from freeadmin.core.models import ModelAdmin
+from freeadmin.hub import admin_site
 
-class ProductImageInline(InlineAdmin):
+from .models import Product
+
+
+class ProductAdmin(ModelAdmin):
+    """List, search, and edit catalog products."""
+
+    list_display = ("id", "name", "price", "available")
+    search_fields = ("name",)
+    ordering = ("name",)
+
+
+admin_site.register(app="catalog", model=Product, admin_cls=ProductAdmin)
+```
+
+* `app` becomes the slug visible in URLs (`/panel/orm/catalog/product/`).
+* `model` is the ORM class itself.
+* `admin_cls` is instantiated lazily by `AdminSite.register()` and receives the
+  adapter defined by the boot process.
+* Optional keyword arguments let you publish the descriptor under
+  `/panel/settings/…` (`settings=True`) or register it in both menus at once via
+  `admin_site.register_both()`.
+
+Registration normally lives in the app’s `admin.py` so that import side effects
+are predictable. If you prefer structured startup logic, wrap the registration
+inside an `AppConfig.startup()` method and import the config in your boot
+sequence.
+
+---
+
+## What a `ModelAdmin` does for you
+
+`ModelAdmin` subclasses inherit a long list of sensible defaults from
+`BaseModelAdmin`. You only override the pieces you want to surface.
+
+### Essential attributes
+
+| Attribute            | Purpose | Story behind it |
+| -------------------- | ------- | --------------- |
+| `label` / `label_singular` | Override the plural and singular captions shown in menus and headers. | Set them when the automatically generated names (`Product` → `Products`) do not read naturally. |
+| `list_display`       | Tuple of column names or callables. | Defaults to every non-primary-key field so the changelist stays informative even if you omit it. |
+| `search_fields`      | Tuple of field names. | If empty, `BaseModelAdmin` inspects your descriptor and automatically includes `CharField`/`TextField` columns without choices. |
+| `list_filter`        | Tuple of dot-separated paths. | Each entry becomes a sidebar filter; related paths such as `"category.name"` are resolved recursively. |
+| `ordering`           | Default ordering sent to the adapter. | Falls back to the model’s primary key when not provided. |
+| `fields`             | Controls the form layout. | When omitted every non-readonly field is shown, honouring `readonly_fields` and implicit defaults. |
+| `readonly_fields`    | Tuple of field names shown as read-only widgets. | Useful for audit fields and computed data. |
+| `autocomplete_fields`| Enables AJAX autocompletion for foreign keys. | FreeAdmin converts matching widgets to async search inputs. |
+| `actions`            | Tuple of subclasses of `BaseAction`. | Defaults to `DeleteSelectedAction` and `ExportSelectedAction`. |
+
+### Enriching the list view with callables
+
+You can add computed columns by defining methods that accept the row object.
+
+```python
+class ProductAdmin(ModelAdmin):
+    list_display = ("id", "name", "price_tag", "available")
+
+    def price_tag(self, obj) -> str:
+        """Format the price including a currency symbol."""
+
+        return f"${obj.price:.2f}"
+```
+
+`BaseModelAdmin` automatically detects these callables and exposes them through
+the metadata API used by the React front end.
+
+### Customising querysets and permissions
+
+Every CRUD operation flows through async hooks that you may override:
+
+* `get_queryset(request, user)` – tweak the base queryset before list
+  operations run.
+* `apply_row_level_security(qs, user)` – enforce per-user filters reused across
+  list, detail, and inline operations.
+* `allow(user, action, obj=None)` – control per-action UI affordances. The base
+  implementation already checks `PermAction` flags and superuser status.
+
+These hooks live in `BaseModelAdmin`, so refer to the inline documentation for
+finer details before overriding them.
+
+---
+
+## Inline editors with `InlineModelAdmin`
+
+Inline descriptors let users edit related rows without leaving the parent form.
+Create a subclass of `freeadmin.core.inline.InlineModelAdmin`, set its `model`
+and tell FreeAdmin which foreign key links it to the parent via
+`parent_fk_name`.
+
+```python
+from freeadmin.core.inline import InlineModelAdmin
+
+from .models import Product, ProductImage
+
+
+class ProductImageInline(InlineModelAdmin):
+    """Manage product imagery alongside the product form."""
+
     model = ProductImage
-    fields = ["image", "alt_text"]
-```
+    parent_fk_name = "product"
+    list_display = ("image", "alt_text")
+    can_delete = True
+    collapsed = False
 
-Attach it to your `ModelAdmin`:
 
-```python
 class ProductAdmin(ModelAdmin):
-    list_display = ["name", "price", "available"]
-    inlines = [ProductImageInline]
+    inlines = (ProductImageInline,)
 ```
 
-> InlineAdmins automatically manage foreign key relations and nested saving logic.
+The admin site instantiates inline classes on demand, injects the same adapter
+used by the parent admin, and surfaces a metadata payload describing columns,
+permissions, and badge counts. Advanced behaviour such as forced foreign key
+headers (`X-Force-FK-<field>`) is already handled inside `BaseModelAdmin.create`
+and `BaseModelAdmin.update`, so inline POST/DELETE requests remain minimal.
 
 ---
 
-## Actions
+## Bulk actions
 
-Actions are operations you can perform on multiple selected objects.
-They can be defined as plain functions or class-based methods.
-
-Example:
+Actions are class-based and inherit from `freeadmin.core.actions.BaseAction`.
+They receive a queryset (or iterable compatible with your adapter), a params
+dictionary, and the current user. Returning an `ActionResult` communicates the
+outcome back to the UI.
 
 ```python
-def mark_as_unavailable(request, queryset):
-    queryset.update(available=False)
+from freeadmin.core.actions import ActionResult, ActionSpec, BaseAction
+
+
+class MarkUnavailableAction(BaseAction):
+    """Flag selected products as unavailable."""
+
+    spec = ActionSpec(
+        name="mark_unavailable",
+        label="Mark as unavailable",
+        description="Set the availability flag to false",
+        danger=False,
+        scope=["change"],
+        params_schema={},
+        required_perm=None,
+    )
+
+    async def run(self, qs, params, user) -> ActionResult:
+        """Update each selected product and report how many rows changed."""
+
+        rows = await self.admin.adapter.fetch_all(qs)
+        for obj in rows:
+            obj.available = False
+            await self.admin.adapter.save(obj)
+        return ActionResult(ok=True, affected=len(rows))
+
 
 class ProductAdmin(ModelAdmin):
-    list_display = ["name", "price", "available"]
-    actions = [mark_as_unavailable]
+    actions = ModelAdmin.actions + (MarkUnavailableAction,)
 ```
 
-For confirmation dialogs or async execution, you can use advanced Action APIs (see the *Advanced Usage* section).
+You can also reuse the built-in `DeleteSelectedAction` and
+`ExportSelectedAction`. The adapter wrapper exposes conveniences like
+`fetch_all`, `assign`, and queryset builders (`filter`, `order_by`), so writing
+async-friendly actions is a matter of orchestrating your domain logic.
 
 ---
 
-## Choices and Enums
+## Working with enums and choice fields
 
-FreeAdmin automatically converts Python Enums or `choices` into dropdown fields.
-
-Example:
+`BaseModelAdmin.get_list_filters()` recognises the `choices` metadata exposed by
+your ORM descriptor. When a field exposes `choices` or derives from
+`CharEnumField`, FreeAdmin renders the widget as a select box automatically.
 
 ```python
-from tortoise import fields
+import enum
+
 
 class Product(Model):
-    class Status:
+    class Status(str, enum.Enum):
         ACTIVE = "active"
         ARCHIVED = "archived"
 
-        CHOICES = [
-            (ACTIVE, "Active"),
-            (ARCHIVED, "Archived"),
-        ]
+    status = fields.CharEnumField(enum_type=Status, default=Status.ACTIVE)
 
-    status = fields.CharEnumField(choices=Status.CHOICES, default=Status.ACTIVE)
-```
 
-In the admin form, this field will appear as a **select box** automatically.
-
----
-
-## Display Methods
-
-You can add computed or formatted columns to your list view by defining methods on your `ModelAdmin`.
-
-```python
 class ProductAdmin(ModelAdmin):
-    list_display = ["name", "price_with_currency", "available"]
-
-    def price_with_currency(self, obj):
-        return f\"${obj.price:.2f}\"
+    list_filter = ("status",)
 ```
 
-> **Note:** These methods must accept one argument (`obj`) and return a string or HTML-safe value.
+The filter sidebar receives the enum values and their display labels; form
+widgets display the same readable names. No extra wiring is required as long as
+your adapter exposes `choices` in its model descriptor.
 
 ---
 
-## Related Models and Foreign Keys
+## Relations and search paths
 
-ForeignKey and ManyToMany relations are rendered automatically as dropdowns or multi-selects, depending on field type.
-
-Example:
+Foreign keys and many-to-many relations are processed automatically by the base
+class. You can reference related fields in `list_display`, `list_filter`, and
+`search_fields` by using Django-style double underscores (e.g.
+`"category__name"`). The admin site resolves these lookups when it builds the
+filter specification.
 
 ```python
 class Category(Model):
     id = fields.IntField(pk=True)
     name = fields.CharField(max_length=100)
 
+
 class Product(Model):
     category = fields.ForeignKeyField("models.Category", related_name="products")
-```
 
-Admin:
 
-```python
 class ProductAdmin(ModelAdmin):
-    list_display = ["name", "category"]
-    search_fields = ["name", "category__name"]
+    list_display = ("name", "category")
+    search_fields = ("name", "category__name")
+    list_filter = ("category",)
 ```
+
+When a user edits a product, FreeAdmin renders the `category` field as a select
+widget, populated through the adapter’s metadata APIs. Many-to-many widgets are
+handled in the same fashion, including add/remove semantics during save.
 
 ---
 
-## Example: Full Application
+## Putting it all together
+
+Here is a compact directory layout to demonstrate how the components fit.
 
 ```
-apps/products/
-├── app.py
-├── models.py
+apps/catalog/
+├── __init__.py
 ├── admin.py
-└── __init__.py
+├── app.py
+└── models.py
 ```
 
 **models.py**
 
 ```python
+from tortoise import fields
+from tortoise.models import Model
+
+
+class Category(Model):
+    id = fields.IntField(pk=True)
+    name = fields.CharField(max_length=100)
+
+
 class Product(Model):
     id = fields.IntField(pk=True)
     name = fields.CharField(max_length=200)
@@ -231,31 +318,73 @@ class Product(Model):
 **admin.py**
 
 ```python
+from freeadmin.core.inline import InlineModelAdmin
+from freeadmin.core.models import ModelAdmin
+from freeadmin.hub import admin_site
+
+from .models import Category, Product
+
+
+class ProductInline(InlineModelAdmin):
+    """Show products inside the category form."""
+
+    model = Product
+    parent_fk_name = "category"
+    list_display = ("name", "price", "available")
+
+
+class CategoryAdmin(ModelAdmin):
+    """Manage catalog categories."""
+
+    list_display = ("name",)
+    inlines = (ProductInline,)
+
+
 class ProductAdmin(ModelAdmin):
-    list_display = ["name", "category", "price", "available"]
-    list_filter = ["category", "available"]
-    search_fields = ["name", "category__name"]
+    """Manage catalog products."""
+
+    list_display = ("name", "category", "price", "available")
+    list_filter = ("category", "available")
+    search_fields = ("name", "category__name")
+
+
+admin_site.register(app="catalog", model=Category, admin_cls=CategoryAdmin)
+admin_site.register(app="catalog", model=Product, admin_cls=ProductAdmin)
 ```
 
 **app.py**
 
 ```python
-class ProductsConfig(AppConfig):
-    def ready(self):
-        self.register(Product, ProductAdmin)
+from freeadmin.core.app import AppConfig
+
+
+class CatalogConfig(AppConfig):
+    """Make the catalog package discoverable by the boot manager."""
+
+    app_label = "catalog"
+    name = "myproject.apps.catalog"
+
+
+default = CatalogConfig()
 ```
+
+Importing `apps.catalog.admin` anywhere in your startup path completes the
+picture: models are available to FreeAdmin, the admin site understands how to
+list them, inline editors surface related data, and default bulk actions are
+ready. From there you can layer in custom permissions, bespoke widgets, or
+domain-specific actions by extending the documented hooks.
 
 ---
 
 ## Summary
 
-| Concept             | Description                             |
-| ------------------- | --------------------------------------- |
-| **Model**           | Defines data schema                     |
-| **ModelAdmin**      | Defines admin presentation              |
-| **InlineAdmin**     | Manages related models                  |
-| **Actions**         | Adds bulk operations                    |
-| **Choices / Enums** | Converts constants into dropdowns       |
-| **Foreign Keys**    | Automatically rendered as select fields |
-
+* Define plain ORM models – the adapter handles metadata and CRUD.
+* Create `ModelAdmin` subclasses to describe how the admin UI should present
+  those models.
+* Register models with `admin_site.register()` (or `register_both()` when you
+  need both ORM and Settings menus).
+* Use `InlineModelAdmin` to embed related rows.
+* Extend bulk behaviour with `BaseAction` subclasses.
+* Let FreeAdmin’s defaults carry the heavy lifting while you focus on domain
+  rules and user experience.
 


### PR DESCRIPTION
## Summary
- align the models and admin models guide with the current FreeAdmin APIs
- expand narrative examples covering registration, inline admins, and bulk actions
- add sections for enums, relation lookups, and complete app wiring

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ebf93122b083308fdd7239d0111eaa