### PR TITLE
Switch FreeAdmin configuration prefix to FA

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ admin.init(app, packages=["apps"])
 ### 4. Run the server
 
 ```bash
-export FREEADMIN_DATABASE_URL="sqlite:///./db.sqlite3"
+export FA_DATABASE_URL="sqlite:///./db.sqlite3"
 freeadmin create-superuser
 uvicorn config.main:app --reload
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,28 +9,28 @@ This chapter focuses on the second group so you know which environment variables
 
 ## Environment variables
 
-`FreeAdminSettings.from_env()` reads variables with the `FREEADMIN_` prefix. Common entries include:
+`FreeAdminSettings.from_env()` reads variables with the `FA_` prefix. Common entries include:
 
 | Variable | Default | Purpose |
 | -------- | ------- | ------- |
-| `FREEADMIN_SECRET_KEY` | `change-me` | Base secret used when other keys are not provided. |
-| `FREEADMIN_SESSION_SECRET` | derived from `SECRET_KEY` | Session signing key for the Starlette session middleware. |
-| `FREEADMIN_CSRF_SECRET` | derived from `SECRET_KEY` | Secret used to sign CSRF tokens. |
-| `FREEADMIN_ADMIN_PATH` | `/panel` | URL prefix where the admin is mounted. |
-| `FREEADMIN_MEDIA_URL` | `/media/` | Public prefix for uploaded files. |
-| `FREEADMIN_MEDIA_ROOT` | `<cwd>/media` | Filesystem path where uploads are stored. |
-| `FREEADMIN_EVENT_CACHE_PATH` | `:memory:` | SQLite file used for caching card payloads (or `:memory:` for in-memory caching). |
-| `FREEADMIN_EVENT_CACHE_IN_MEMORY` | inferred | Force in-memory caching even if a path is supplied. |
-| `FREEADMIN_JWT_SECRET_KEY` | `None` | Secret used when generating API tokens. |
-| `FREEADMIN_ACTION_BATCH_SIZE` | `50` | Maximum number of objects processed per action batch. |
-| `FREEADMIN_CARD_EVENTS_TOKEN_TTL` | `3600` | Lifetime (seconds) for card SSE tokens. |
-| `FREEADMIN_ADMIN_SITE_TITLE` | `FreeAdmin` | Displayed in the page title and navigation. |
-| `FREEADMIN_BRAND_ICON` | empty | Path or URL to the brand icon shown in the header. |
-| `FREEADMIN_DATABASE_URL` | `None` | Database DSN used by the bundled Tortoise adapter. |
-| `FREEADMIN_STATIC_URL_SEGMENT` | `/static` | URL path for FreeAdmin static assets. |
-| `FREEADMIN_STATIC_ROUTE_NAME` | `admin-static` | Route name used when mounting static files. |
-| `FREEADMIN_EXPORT_CACHE_PATH` | `<cwd>/freeadmin-export-cache.sqlite3` | SQLite file used for temporary export data. |
-| `FREEADMIN_EXPORT_CACHE_TTL` | `300` | Cache lifetime for export artefacts. |
+| `FA_SECRET_KEY` | `change-me` | Base secret used when other keys are not provided. |
+| `FA_SESSION_SECRET` | derived from `SECRET_KEY` | Session signing key for the Starlette session middleware. |
+| `FA_CSRF_SECRET` | derived from `SECRET_KEY` | Secret used to sign CSRF tokens. |
+| `FA_ADMIN_PATH` | `/panel` | URL prefix where the admin is mounted. |
+| `FA_MEDIA_URL` | `/media/` | Public prefix for uploaded files. |
+| `FA_MEDIA_ROOT` | `<cwd>/media` | Filesystem path where uploads are stored. |
+| `FA_EVENT_CACHE_PATH` | `:memory:` | SQLite file used for caching card payloads (or `:memory:` for in-memory caching). |
+| `FA_EVENT_CACHE_IN_MEMORY` | inferred | Force in-memory caching even if a path is supplied. |
+| `FA_JWT_SECRET_KEY` | `None` | Secret used when generating API tokens. |
+| `FA_ACTION_BATCH_SIZE` | `50` | Maximum number of objects processed per action batch. |
+| `FA_CARD_EVENTS_TOKEN_TTL` | `3600` | Lifetime (seconds) for card SSE tokens. |
+| `FA_ADMIN_SITE_TITLE` | `FreeAdmin` | Displayed in the page title and navigation. |
+| `FA_BRAND_ICON` | empty | Path or URL to the brand icon shown in the header. |
+| `FA_DATABASE_URL` | `None` | Database DSN used by the bundled Tortoise adapter. |
+| `FA_STATIC_URL_SEGMENT` | `/static` | URL path for FreeAdmin static assets. |
+| `FA_STATIC_ROUTE_NAME` | `admin-static` | Route name used when mounting static files. |
+| `FA_EXPORT_CACHE_PATH` | `<cwd>/freeadmin-export-cache.sqlite3` | SQLite file used for temporary export data. |
+| `FA_EXPORT_CACHE_TTL` | `300` | Cache lifetime for export artefacts. |
 
 Set these variables before your process starts (for example in a `.env` file, Docker container, or process manager). When a variable is not provided FreeAdmin falls back to sensible defaults and ensures derived values stay consistent (for example `session_secret` defaults to `secret_key`).
 
@@ -71,21 +71,21 @@ class ProjectSettings(BaseSettings):
 settings = ProjectSettings()
 ```
 
-You can combine both settings layers by exporting `FREEADMIN_DATABASE_URL` from the same `.env` file used by your project settings. FreeAdmin's boot manager will pick up the database URL automatically when initialising the Tortoise adapter.
+You can combine both settings layers by exporting `FA_DATABASE_URL` from the same `.env` file used by your project settings. FreeAdmin's boot manager will pick up the database URL automatically when initialising the Tortoise adapter.
 
 
 ## Database URL
 
-The bundled Tortoise adapter reads `FREEADMIN_DATABASE_URL`. If the variable is absent FreeAdmin falls back to the value returned by `ProjectSettings.database_url` (if present) or leaves the connection unconfigured. Define the variable explicitly to avoid surprises:
+The bundled Tortoise adapter reads `FA_DATABASE_URL`. If the variable is absent FreeAdmin falls back to the value returned by `ProjectSettings.database_url` (if present) or leaves the connection unconfigured. Define the variable explicitly to avoid surprises:
 
 ```bash
-export FREEADMIN_DATABASE_URL="sqlite:///./db.sqlite3"
+export FA_DATABASE_URL="sqlite:///./db.sqlite3"
 ```
 
 For PostgreSQL:
 
 ```bash
-export FREEADMIN_DATABASE_URL="postgres://user:password@localhost:5432/mydb"
+export FA_DATABASE_URL="postgres://user:password@localhost:5432/mydb"
 ```
 
 Ensure the same value is used inside `config/orm.py` when you initialise Tortoise so the CLI commands and your application share the configuration.
@@ -93,15 +93,15 @@ Ensure the same value is used inside `config/orm.py` when you initialise Tortois
 
 ## Static and media files
 
-`BootManager` mounts FreeAdmin's bundled static files (Bootstrap, Choices.js, JSONEditor, etc.) at the prefix determined by `FREEADMIN_STATIC_URL_SEGMENT`. Your project-specific assets can live inside the scaffolded `static/` directory. To expose uploaded files, configure `FREEADMIN_MEDIA_ROOT` and `FREEADMIN_MEDIA_URL` – the template provider automatically serves this folder.
+`BootManager` mounts FreeAdmin's bundled static files (Bootstrap, Choices.js, JSONEditor, etc.) at the prefix determined by `FA_STATIC_URL_SEGMENT`. Your project-specific assets can live inside the scaffolded `static/` directory. To expose uploaded files, configure `FA_MEDIA_ROOT` and `FA_MEDIA_URL` – the template provider automatically serves this folder.
 
 
 ## Branding and presentation
 
 Two settings control the visible branding:
 
-* `FREEADMIN_ADMIN_SITE_TITLE` – shown in the `<title>` tag and navigation header.
-* `FREEADMIN_BRAND_ICON` – path or URL to an icon displayed in the top-left corner.
+* `FA_ADMIN_SITE_TITLE` – shown in the `<title>` tag and navigation header.
+* `FA_BRAND_ICON` – path or URL to an icon displayed in the top-left corner.
 
 Changes are reflected the next time the admin hub is created. If you adjust the settings at runtime, the observer mechanism in `BootManager` propagates the new values to the card manager and menu caches.
 
@@ -110,8 +110,8 @@ Changes are reflected the next time the admin hub is created. If you adjust the 
 
 For production environments:
 
-* Generate a strong `FREEADMIN_SECRET_KEY`. This value seeds all other secrets.
-* Consider setting distinct values for `FREEADMIN_SESSION_SECRET` and `FREEADMIN_CSRF_SECRET` to rotate them independently.
+* Generate a strong `FA_SECRET_KEY`. This value seeds all other secrets.
+* Consider setting distinct values for `FA_SESSION_SECRET` and `FA_CSRF_SECRET` to rotate them independently.
 * Store secrets in a vault or secret manager rather than committing them to source control.
 
 ## Visual configuration interface
@@ -123,7 +123,7 @@ FreeAdmin ships with a built-in settings editor available from the admin navigat
 ## Troubleshooting
 
 * **Settings do not change after editing `.env`:** ensure the process reads the file before `BootManager` is imported. The simplest approach is to load environment variables at the top of `config/main.py`.
-* **Static files return 404:** verify `FREEADMIN_STATIC_URL_SEGMENT` matches the path registered by `TemplateProvider.mount_static()` and that your ASGI server serves mounted routes.
-* **Card updates are lost between restarts:** set `FREEADMIN_EVENT_CACHE_PATH` to a persistent location so the SQLite cache survives restarts, and disable `FREEADMIN_EVENT_CACHE_IN_MEMORY` if necessary.
+* **Static files return 404:** verify `FA_STATIC_URL_SEGMENT` matches the path registered by `TemplateProvider.mount_static()` and that your ASGI server serves mounted routes.
+* **Card updates are lost between restarts:** set `FA_EVENT_CACHE_PATH` to a persistent location so the SQLite cache survives restarts, and disable `FA_EVENT_CACHE_IN_MEMORY` if necessary.
 
 With these settings in place you can control the admin panel's URL structure, caching behaviour, and security posture without modifying the core library.

--- a/docs/core-concepts-and-terminology.md
+++ b/docs/core-concepts-and-terminology.md
@@ -203,7 +203,7 @@ Widgets are frontend components referenced from `ModelAdmin.widgets_overrides` o
 
 ## Settings
 
-Global configuration lives inside `freeadmin.conf.FreeAdminSettings`. Instances are normally created with `FreeAdminSettings.from_env()`, which reads environment variables prefixed with `FREEADMIN_`.
+Global configuration lives inside `freeadmin.conf.FreeAdminSettings`. Instances are normally created with `FreeAdminSettings.from_env()`, which reads environment variables prefixed with `FA_`.
 
 Important attributes include:
 

--- a/docs/installation-and-cli.md
+++ b/docs/installation-and-cli.md
@@ -197,15 +197,15 @@ async def startup() -> None:
 boot.init(app, packages=["apps"])
 ```
 
-The call to `boot.init()` mounts the admin routes at the path configured by `FREEADMIN_ADMIN_PATH` (default `/panel`) and schedules background services such as card publishers.
+The call to `boot.init()` mounts the admin routes at the path configured by `FA_ADMIN_PATH` (default `/panel`) and schedules background services such as card publishers.
 
 
 ## Step 9. Configure the database URL
 
-FreeAdmin reads `FREEADMIN_DATABASE_URL` when using the bundled Tortoise adapter. Export the variable or set it in your process manager before running the app:
+FreeAdmin reads `FA_DATABASE_URL` when using the bundled Tortoise adapter. Export the variable or set it in your process manager before running the app:
 
 ```bash
-export FREEADMIN_DATABASE_URL="sqlite:///./db.sqlite3"
+export FA_DATABASE_URL="sqlite:///./db.sqlite3"
 ```
 
 For PostgreSQL use a DSN such as `postgres://user:password@localhost:5432/mydb`.
@@ -238,6 +238,6 @@ Visit `http://127.0.0.1:8000/panel` (or the prefix you configured) and sign in w
 * **CLI cannot find `apps/`:** run the command from the project root where the scaffold created the folder.
 * **Models not discovered:** ensure the module path (e.g. `apps.blog.models`) is listed in `modules["models"]` when initialising Tortoise.
 * **Missing static assets:** verify that `freeadmin.boot.BootManager.init()` has been called and that your ASGI server can serve the mounted static route.
-* **Session errors:** set `FREEADMIN_SESSION_SECRET` to a stable value in production so session cookies remain valid across restarts.
+* **Session errors:** set `FA_SESSION_SECRET` to a stable value in production so session cookies remain valid across restarts.
 
 With these steps you now have a working FreeAdmin installation backed by FastAPI and Tortoise ORM. Continue exploring the other documentation chapters for more detail on cards, permissions, and custom views.

--- a/freeadmin/conf.py
+++ b/freeadmin/conf.py
@@ -79,7 +79,7 @@ class FreeAdminSettings:
         cls,
         env: Mapping[str, str] | None = None,
         *,
-        prefix: str = "FREEADMIN_",
+        prefix: str = "FA_",
     ) -> "FreeAdminSettings":
         """Build a settings instance from environment variables."""
         source = env or os.environ

--- a/freeadmin/utils/cli/create_superuser.py
+++ b/freeadmin/utils/cli/create_superuser.py
@@ -52,7 +52,7 @@ class SuperuserCreator:
             return
         db_url = self._settings.database_url
         if not db_url:
-            raise RuntimeError("FREEADMIN_DATABASE_URL is required for ORM initialization")
+            raise RuntimeError("FA_DATABASE_URL is required for ORM initialization")
         from tortoise import Tortoise  # lazy import to avoid hard dependency at module load
 
         modules = {"models": list(self.adapter.model_modules)}

--- a/tests/test_conf_event_cache.py
+++ b/tests/test_conf_event_cache.py
@@ -39,8 +39,8 @@ def test_settings_from_env_forces_memory_mode() -> None:
     """Check environment overrides can force in-memory behaviour."""
 
     env = {
-        "FREEADMIN_EVENT_CACHE_PATH": "/tmp/ignored.sqlite3",
-        "FREEADMIN_EVENT_CACHE_IN_MEMORY": "true",
+        "FA_EVENT_CACHE_PATH": "/tmp/ignored.sqlite3",
+        "FA_EVENT_CACHE_IN_MEMORY": "true",
     }
 
     settings = FreeAdminSettings.from_env(env)
@@ -53,7 +53,7 @@ def test_settings_from_env_persistent_with_default_file(tmp_path, monkeypatch) -
     """Confirm disabling memory cache selects a default persistent path."""
 
     env = {
-        "FREEADMIN_EVENT_CACHE_IN_MEMORY": "false",
+        "FA_EVENT_CACHE_IN_MEMORY": "false",
     }
 
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary
- replace the FREEADMIN_ environment variable prefix with FA_ across configuration, docs, and tests
- update the CLI error message to reference the new FA_DATABASE_URL variable
- adjust configuration loading default prefix to use FA_

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eccaabaeb0833099d125b9a89e599f