### PR TITLE
Switch default admin path to /admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ freeadmin create-superuser
 uvicorn config.main:app --reload
 ```
 
-Open [http://127.0.0.1:8000/panel](http://127.0.0.1:8000/panel) and log in with the credentials you created.
+Open [http://127.0.0.1:8000/admin](http://127.0.0.1:8000/admin) and log in with the credentials you created.
 
 ## Documentation
 

--- a/docs/admin/RBAC.md
+++ b/docs/admin/RBAC.md
@@ -134,7 +134,7 @@ Each CRUD route maps to exactly one permission action. A dependency reads the
 `{app, model}` from the path, resolves the `ct_id` via
 `AdminSite.get_ct_id()` and enforces the required permission.
 
-The leading `/panel/orm/` segment comes from configuration: `panel` is the
+The leading `/admin/orm/` segment comes from configuration: `admin` is the
 `ADMIN_PREFIX` and `orm` is `PAGE_TYPE_ORM`, both defined in project
 settings.
 
@@ -142,11 +142,11 @@ settings.
 
 | HTTP route                                         | Action |
 | -------------------------------------------------- | ------ |
-| `GET /panel/orm/{app}/{model}/_list`               | view   |
-| `GET /panel/orm/{app}/{model}/{id}`                | view   |
-| `POST /panel/orm/{app}/{model}/`                   | add    |
-| `PUT/PATCH /panel/orm/{app}/{model}/{id}`          | change |
-| `DELETE /panel/orm/{app}/{model}/{id}`             | delete |
+| `GET /admin/orm/{app}/{model}/_list`               | view   |
+| `GET /admin/orm/{app}/{model}/{id}`                | view   |
+| `POST /admin/orm/{app}/{model}/`                   | add    |
+| `PUT/PATCH /admin/orm/{app}/{model}/{id}`          | change |
+| `DELETE /admin/orm/{app}/{model}/{id}`             | delete |
 
 ### Applying the Dependency
 

--- a/docs/admin/api.md
+++ b/docs/admin/api.md
@@ -6,7 +6,7 @@ into templates as the `window.ADMIN_API` object so that JavaScript and Python
 share the same values. See [System Settings](settings.md) for the full list of
 configuration keys and defaults:
 
-The examples assume the default prefixes `ADMIN_PREFIX=/panel`,
+The examples assume the default prefixes `ADMIN_PREFIX=/admin`,
 `API_PREFIX=/api`, and `API_LOOKUP=/lookup`; each value can be customized in
 the system settings.
 

--- a/docs/admin/pages.md
+++ b/docs/admin/pages.md
@@ -77,7 +77,7 @@ async def blog_stats_view(request: Request):
 > **Note:** `AdminRouter.mount()` automatically adds the admin base path as a prefix,
 > so the route above resolves under the admin namespace without additional changes. Avoid
 > duplicating the admin prefix when registering the view; otherwise the final endpoint would
-> mount at `/panel/panel/...`, breaking `AdminSite.parse_section_path()` and sidebar
+> mount at `/admin/admin/...`, breaking `AdminSite.parse_section_path()` and sidebar
 > highlighting.
 
 The sidebar renders standalone views alongside registered models. When the `Blog` application exposes both a `PostAdmin` model and the

--- a/docs/admin/settings.md
+++ b/docs/admin/settings.md
@@ -41,7 +41,7 @@ await system_config.reload()
 | `DEFAULT_PER_PAGE` | Default page size | `20` | `int` |
 | `MAX_PER_PAGE` | Max page size | `100` | `int` |
 | `ACTION_BATCH_SIZE` | Batch size for admin actions | `100` | `int` |
-| `ADMIN_PREFIX` | Admin path prefix used to build final admin URLs; other paths like `LOGIN_PATH` and `LOGOUT_PATH` are appended to this prefix | `/panel` | `string` |
+| `ADMIN_PREFIX` | Admin path prefix used to build final admin URLs; other paths like `LOGIN_PATH` and `LOGOUT_PATH` are appended to this prefix | `/admin` | `string` |
 | `API_PREFIX` | API prefix | `/api` | `string` |
 | `API_SCHEMA` | Schema endpoint | `/schema` | `string` |
 | `API_LIST_FILTERS` | List filters endpoint | `/list_filters` | `string` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,7 @@ This chapter focuses on the second group so you know which environment variables
 | `FA_SECRET_KEY` | `change-me` | Base secret used when other keys are not provided. |
 | `FA_SESSION_SECRET` | derived from `SECRET_KEY` | Session signing key for the Starlette session middleware. |
 | `FA_CSRF_SECRET` | derived from `SECRET_KEY` | Secret used to sign CSRF tokens. |
-| `FA_ADMIN_PATH` | `/panel` | URL prefix where the admin is mounted. |
+| `FA_ADMIN_PATH` | `/admin` | URL prefix where the admin is mounted. |
 | `FA_MEDIA_URL` | `/media/` | Public prefix for uploaded files. |
 | `FA_MEDIA_ROOT` | `<cwd>/media` | Filesystem path where uploads are stored. |
 | `FA_EVENT_CACHE_PATH` | `:memory:` | SQLite file used for caching card payloads (or `:memory:` for in-memory caching). |
@@ -32,7 +32,7 @@ This chapter focuses on the second group so you know which environment variables
 | `FA_EXPORT_CACHE_PATH` | `<cwd>/freeadmin-export-cache.sqlite3` | SQLite file used for temporary export data. |
 | `FA_EXPORT_CACHE_TTL` | `300` | Cache lifetime for export artefacts. |
 
-Set these variables before your process starts (for example in a `.env` file, Docker container, or process manager). When a variable is not provided FreeAdmin falls back to sensible defaults and ensures derived values stay consistent (for example `session_secret` defaults to `secret_key`).
+Set these variables before your process starts (for example in a `.env` file, Docker container, or process manager). When a variable is not provided FreeAdmin falls back to sensible defaults and ensures derived values stay consistent (for example `session_secret` defaults to `secret_key`). Consider overriding `FA_ADMIN_PATH` in production to an uncommon value so automated scans cannot easily discover the admin endpoint.
 
 
 ## Programmatic configuration
@@ -111,6 +111,7 @@ Changes are reflected the next time the admin hub is created. If you adjust the 
 For production environments:
 
 * Generate a strong `FA_SECRET_KEY`. This value seeds all other secrets.
+* Change `FA_ADMIN_PATH` from the default `/admin` to a project-specific value to reduce the chance of automated probing.
 * Consider setting distinct values for `FA_SESSION_SECRET` and `FA_CSRF_SECRET` to rotate them independently.
 * Store secrets in a vault or secret manager rather than committing them to source control.
 

--- a/docs/core-concepts-and-terminology.md
+++ b/docs/core-concepts-and-terminology.md
@@ -83,7 +83,7 @@ boot = BootManager(adapter_name="tortoise")
 boot.init(app, packages=["my_project.apps"])
 ```
 
-This snippet initialises the adapter, discovers admin registrations inside `my_project.apps`, and mounts the admin interface at the path configured in `FreeAdminSettings.admin_path` (default `/panel`).
+This snippet initialises the adapter, discovers admin registrations inside `my_project.apps`, and mounts the admin interface at the path configured in `FreeAdminSettings.admin_path` (default `/admin`).
 
 
 ## AdminRouter
@@ -207,7 +207,7 @@ Global configuration lives inside `freeadmin.conf.FreeAdminSettings`. Instances 
 
 Important attributes include:
 
-* `admin_path`: the URL prefix where the admin is mounted (default `/panel`).
+* `admin_path`: the URL prefix where the admin is mounted (default `/admin`).
 * `session_secret` and `csrf_secret`: keys used for securing sessions and forms.
 * `event_cache_path`: storage location for card payload caching.
 * `brand_icon` and `admin_site_title`: values shown in the UI.

--- a/docs/first-run-example.md
+++ b/docs/first-run-example.md
@@ -21,7 +21,7 @@ app = application.configure()
 `ExampleApplication` wires three responsibilities:
 
 * `ExampleSettings` (`example/config/settings.py`) keeps track of project
-  metadata, the admin path (`/panel`), and the list of installed apps. Its
+  metadata, the admin path (`/admin`), and the list of installed apps. Its
   `describe()` helper returns a concise summary that is useful for debugging
   configuration during development.
 * `ExampleORMConfig` (`example/config/orm.py`) declares which adapter to use
@@ -73,7 +73,7 @@ app = application.configure()
        return application.configure()
    ```
 
-   The admin interface will be available at `http://127.0.0.1:8000/panel` once
+   The admin interface will be available at `http://127.0.0.1:8000/admin` once
    the server is running. On the first visit you will be redirected to the
    built-in setup screen where you can create the initial superuser. You can
    also create it ahead of time from the command line:

--- a/docs/installation-and-cli.md
+++ b/docs/installation-and-cli.md
@@ -197,7 +197,7 @@ async def startup() -> None:
 boot.init(app, packages=["apps"])
 ```
 
-The call to `boot.init()` mounts the admin routes at the path configured by `FA_ADMIN_PATH` (default `/panel`) and schedules background services such as card publishers.
+The call to `boot.init()` mounts the admin routes at the path configured by `FA_ADMIN_PATH` (default `/admin`) and schedules background services such as card publishers.
 
 
 ## Step 9. Configure the database URL
@@ -230,7 +230,7 @@ Use Uvicorn (or your ASGI server of choice) to run the FastAPI application:
 uvicorn config.main:app --reload
 ```
 
-Visit `http://127.0.0.1:8000/panel` (or the prefix you configured) and sign in with the credentials created in the previous step. The default interface includes list and detail views for any registered `ModelAdmin`, plus navigation for cards and custom pages.
+Visit `http://127.0.0.1:8000/admin` (or the prefix you configured) and sign in with the credentials created in the previous step. The default interface includes list and detail views for any registered `ModelAdmin`, plus navigation for cards and custom pages.
 
 
 ## Step 12. Troubleshooting tips

--- a/docs/models-and-admin-models.md
+++ b/docs/models-and-admin-models.md
@@ -75,12 +75,12 @@ class ProductAdmin(ModelAdmin):
 admin_site.register(app="catalog", model=Product, admin_cls=ProductAdmin)
 ```
 
-* `app` becomes the slug visible in URLs (`/panel/orm/catalog/product/`).
+* `app` becomes the slug visible in URLs (`/admin/orm/catalog/product/`).
 * `model` is the ORM class itself.
 * `admin_cls` is instantiated lazily by `AdminSite.register()` and receives the
   adapter defined by the boot process.
 * Optional keyword arguments let you publish the descriptor under
-  `/panel/settings/…` (`settings=True`) or register it in both menus at once via
+  `/admin/settings/…` (`settings=True`) or register it in both menus at once via
   `admin_site.register_both()`.
 
 Registration normally lives in the app’s `admin.py` so that import side effects

--- a/example/config/settings.py
+++ b/example/config/settings.py
@@ -19,7 +19,7 @@ from typing import ClassVar
 class ExampleSettings:
     """Store runtime metadata for the FreeAdmin example project."""
 
-    ADMIN_PATH: ClassVar[str] = "/panel"
+    ADMIN_PATH: ClassVar[str] = "/admin"
     INSTALLED_APPS: ClassVar[list[str]] = [
         "example.apps.demo",
     ]

--- a/freeadmin/conf.py
+++ b/freeadmin/conf.py
@@ -25,7 +25,7 @@ class FreeAdminSettings:
     secret_key: str = field(default_factory=lambda: "change-me")
     session_secret: str | None = None
     csrf_secret: str | None = None
-    admin_path: str = "/panel"
+    admin_path: str = "/admin"
     media_url: str = "/media/"
     media_root: Path = field(default_factory=lambda: Path.cwd() / "media")
     event_cache_path: str = ":memory:"
@@ -87,7 +87,7 @@ class FreeAdminSettings:
         secret_key = data.get("SECRET_KEY") or source.get("SECRET_KEY") or "change-me"
         session_secret = data.get("SESSION_SECRET")
         csrf_secret = data.get("CSRF_SECRET")
-        admin_path = data.get("ADMIN_PATH") or "/panel"
+        admin_path = data.get("ADMIN_PATH") or "/admin"
         media_url = data.get("MEDIA_URL") or "/media/"
         media_root = data.get("MEDIA_ROOT") or (Path.cwd() / "media")
         cache_path_raw = data.get("EVENT_CACHE_PATH")

--- a/freeadmin/core/settings/defaults.py
+++ b/freeadmin/core/settings/defaults.py
@@ -13,7 +13,7 @@ from .keys import SettingsKey
 
 DEFAULT_SETTINGS: dict[SettingsKey, tuple[object, str]] = {
     # Admin path
-    SettingsKey.ADMIN_PREFIX:         ("/panel", "string"),
+    SettingsKey.ADMIN_PREFIX:         ("/admin", "string"),
 
     # Titles / Pages
     SettingsKey.DEFAULT_ADMIN_TITLE:   ("FastAPI FreeAdmin", "string"),

--- a/tests/test_export_import.py
+++ b/tests/test_export_import.py
@@ -130,14 +130,14 @@ class TestExportImport:
         asyncio.run(_clear())
         first = asyncio.run(ExportItem.create(name="one", description="1"))
         second = asyncio.run(ExportItem.create(name="two", description="2"))
-        resp = self.client.post("/panel/orm/models/item/export")
+        resp = self.client.post("/admin/orm/models/item/export")
         assert resp.status_code == 200
         rows = resp.json()["rows"]
         assert {"id": first.id, "name": "one", "description": "1"} in rows
         assert {"id": second.id, "name": "two", "description": "2"} in rows
 
     def test_export_response_type(self) -> None:
-        resp = self.client.post("/panel/orm/models/item/export")
+        resp = self.client.post("/admin/orm/models/item/export")
         assert resp.status_code == 200
         assert resp.headers["content-type"].startswith("application/json")
         assert isinstance(resp.json()["rows"], list)
@@ -150,7 +150,7 @@ class TestExportImport:
         asyncio.run(_clear())
         parent = asyncio.run(ExportItem.create(name="parent", description="p"))
         child = asyncio.run(ExportChild.create(label="c", parent=parent))
-        resp = self.client.post("/panel/orm/models/child/export")
+        resp = self.client.post("/admin/orm/models/child/export")
         assert resp.status_code == 200
         rows = resp.json()["rows"]
         assert {"id": child.id, "label": "c", "parent": parent.id} in rows
@@ -167,7 +167,7 @@ class TestExportImport:
             ],
             "dry": True,
         }
-        resp = self.client.post("/panel/orm/models/item/import", json=payload)
+        resp = self.client.post("/admin/orm/models/item/import", json=payload)
         assert resp.status_code == 200
         assert resp.json()["count"] == 2
 
@@ -182,7 +182,7 @@ class TestExportImport:
                 {"name": "b", "description": "bbb"},
             ]
         }
-        resp = self.client.post("/panel/orm/models/item/import", json=payload)
+        resp = self.client.post("/admin/orm/models/item/import", json=payload)
         assert resp.status_code == 200
         assert resp.json()["count"] == 2
         assert asyncio.run(_count()) == 2
@@ -198,7 +198,7 @@ class TestExportImport:
                 {"name": "c", "description": "ccc"},
             ]
         }
-        resp = self.client.post("/panel/orm/models/item/import", json=payload)
+        resp = self.client.post("/admin/orm/models/item/import", json=payload)
         assert resp.status_code == 200
         assert resp.json()["count"] == 2
         assert asyncio.run(_count()) == 3
@@ -215,7 +215,7 @@ class TestExportImport:
 
         asyncio.run(_clear())
         payload = {"rows": [{"name": "z", "description": "zzz"}], "dry": True}
-        resp = self.client.post("/panel/orm/models/item/import", json=payload)
+        resp = self.client.post("/admin/orm/models/item/import", json=payload)
         assert resp.status_code == 200
         body = resp.json()
         assert body["dry"] is True

--- a/tests/test_export_import_wizards.py
+++ b/tests/test_export_import_wizards.py
@@ -178,7 +178,7 @@ class TestExportImportWizards:
             sys.modules.pop("freeadmin.adapters.tortoise.users", None)
 
     def test_export_wizard_lists_fields(self) -> None:
-        resp = self.client.get("/panel/orm/models/item/export/")
+        resp = self.client.get("/admin/orm/models/item/export/")
         assert resp.status_code == 200
         page = self.ExportWizardPage(resp.text)
         expected = list(self.admin.get_export_fields())
@@ -187,7 +187,7 @@ class TestExportImportWizards:
         assert len(values) == len(expected)
 
     def test_export_wizard_fields_selected_by_default(self) -> None:
-        resp = self.client.get("/panel/orm/models/item/export/")
+        resp = self.client.get("/admin/orm/models/item/export/")
         assert resp.status_code == 200
         page = self.ExportWizardPage(resp.text)
         expected = list(self.admin.get_export_fields())
@@ -196,7 +196,7 @@ class TestExportImportWizards:
         assert len(selected) == len(expected)
 
     def test_export_wizard_has_back_button(self) -> None:
-        resp = self.client.get("/panel/orm/models/item/export/")
+        resp = self.client.get("/admin/orm/models/item/export/")
         assert resp.status_code == 200
         page = self.ExportWizardPage(resp.text)
         assert page.has_back_button()
@@ -218,7 +218,7 @@ class TestExportImportWizards:
             },
         }
         resp = self.client.post(
-            "/panel/orm/models/item/export/preview", json=payload_filters
+            "/admin/orm/models/item/export/preview", json=payload_filters
         )
         assert resp.status_code == 200
         body = resp.json()
@@ -239,7 +239,7 @@ class TestExportImportWizards:
             "scope": {"type": "ids", "ids": [first.id, third.id]},
         }
         resp = self.client.post(
-            "/panel/orm/models/item/export/preview", json=payload_ids
+            "/admin/orm/models/item/export/preview", json=payload_ids
         )
         assert resp.status_code == 200
         body = resp.json()
@@ -260,7 +260,7 @@ class TestExportImportWizards:
             "scope": {"type": "query", "query": {"filters": {}}},
         }
         resp = self.client.post(
-            "/panel/orm/models/item/export/preview", json=payload_all
+            "/admin/orm/models/item/export/preview", json=payload_all
         )
         assert resp.status_code == 200
         body = resp.json()
@@ -280,7 +280,7 @@ class TestExportImportWizards:
         }
         for fmt, mime in formats.items():
             resp = self.client.post(
-                "/panel/orm/models/item/export/run",
+                "/admin/orm/models/item/export/run",
                 json={
                     "fmt": fmt,
                     "scope": {"type": "query", "query": {"filters": {}}},
@@ -288,7 +288,7 @@ class TestExportImportWizards:
             )
             assert resp.status_code == 200
             token = resp.json()["token"]
-            resp_file = self.client.get(f"/panel/orm/models/item/export/done/{token}")
+            resp_file = self.client.get(f"/admin/orm/models/item/export/done/{token}")
             assert resp_file.status_code == 200
             assert resp_file.headers["content-type"] == mime
             assert resp_file.headers["content-disposition"].startswith(
@@ -327,12 +327,12 @@ class TestExportImportWizards:
             },
         }
         resp = self.client.post(
-            "/panel/orm/models/item/export/run", json=payload
+            "/admin/orm/models/item/export/run", json=payload
         )
         assert resp.status_code == 200
         token = resp.json()["token"]
         resp_file = self.client.get(
-            f"/panel/orm/models/item/export/done/{token}"
+            f"/admin/orm/models/item/export/done/{token}"
         )
         assert resp_file.status_code == 200
         rows = json.loads(resp_file.content.decode())
@@ -354,12 +354,12 @@ class TestExportImportWizards:
             "scope": {"type": "ids", "ids": [first.id, third.id]},
         }
         resp = self.client.post(
-            "/panel/orm/models/item/export/run", json=payload
+            "/admin/orm/models/item/export/run", json=payload
         )
         assert resp.status_code == 200
         token = resp.json()["token"]
         resp_file = self.client.get(
-            f"/panel/orm/models/item/export/done/{token}"
+            f"/admin/orm/models/item/export/done/{token}"
         )
         assert resp_file.status_code == 200
         rows = json.loads(resp_file.content.decode())
@@ -384,12 +384,12 @@ class TestExportImportWizards:
             "scope_token": token,
         }
         resp = self.client.post(
-            "/panel/orm/models/item/export/run", json=payload
+            "/admin/orm/models/item/export/run", json=payload
         )
         assert resp.status_code == 200
         token = resp.json()["token"]
         resp_file = self.client.get(
-            f"/panel/orm/models/item/export/done/{token}"
+            f"/admin/orm/models/item/export/done/{token}"
         )
         assert resp_file.status_code == 200
         rows = json.loads(resp_file.content.decode())
@@ -399,24 +399,24 @@ class TestExportImportWizards:
     def test_export_endpoints_without_permission(self) -> None:
         self.user.permissions.discard(PermAction.export)
         resp = self.client.post(
-            "/panel/orm/models/item/export/preview", json={}
+            "/admin/orm/models/item/export/preview", json={}
         )
         assert resp.status_code == status.HTTP_403_FORBIDDEN
         assert resp.json() == {"detail": "Export not permitted"}
         resp = self.client.post(
-            "/panel/orm/models/item/export/run", json={}
+            "/admin/orm/models/item/export/run", json={}
         )
         assert resp.status_code == status.HTTP_403_FORBIDDEN
         assert resp.json() == {"detail": "Export not permitted"}
         resp = self.client.get(
-            "/panel/orm/models/item/export/done/invalid-token"
+            "/admin/orm/models/item/export/done/invalid-token"
         )
         assert resp.status_code == status.HTTP_403_FORBIDDEN
         assert resp.json() == {"detail": "Export not permitted"}
         self.user.permissions.add(PermAction.export)
 
     def test_import_wizard_has_back_button(self) -> None:
-        resp = self.client.get("/panel/orm/models/item/import/")
+        resp = self.client.get("/admin/orm/models/item/import/")
         assert resp.status_code == 200
         page = self.ImportWizardPage(resp.text)
         assert page.has_back_button()
@@ -425,14 +425,14 @@ class TestExportImportWizards:
         self.user.permissions.discard(getattr(PermAction, "import"))
         csv_data = "id,name,description\n1,foo,bar\n"
         resp = self.client.post(
-            "/panel/orm/models/item/import/preview",
+            "/admin/orm/models/item/import/preview",
             files={"file": ("items.csv", csv_data, "text/csv")},
             data={"fields": ["id", "name", "description"]},
         )
         assert resp.status_code == status.HTTP_403_FORBIDDEN
         assert resp.json() == {"detail": "Import not permitted"}
         resp = self.client.post(
-            "/panel/orm/models/item/import/run",
+            "/admin/orm/models/item/import/run",
             json={"token": "dummy", "fields": ["id"]},
         )
         assert resp.status_code == status.HTTP_403_FORBIDDEN
@@ -454,7 +454,7 @@ class TestExportImportWizards:
             "scope": {"type": "query", "query": {"filters": {}}},
         }
         resp = self.client.post(
-            "/panel/orm/models/item/export/preview", json=payload_preview
+            "/admin/orm/models/item/export/preview", json=payload_preview
         )
         assert resp.status_code == 200
 
@@ -463,12 +463,12 @@ class TestExportImportWizards:
             "scope": {"type": "query", "query": {"filters": {}}},
         }
         resp_run = self.client.post(
-            "/panel/orm/models/item/export/run", json=payload_run
+            "/admin/orm/models/item/export/run", json=payload_run
         )
         assert resp_run.status_code == 200
         token = resp_run.json()["token"]
         resp_done = self.client.get(
-            f"/panel/orm/models/item/export/done/{token}"
+            f"/admin/orm/models/item/export/done/{token}"
         )
         assert resp_done.status_code == 200
 
@@ -485,7 +485,7 @@ class TestExportImportWizards:
             rows.append(f"{i + 1},item{i},desc{i}\n")
         csv_data = "".join(rows)
         resp = self.client.post(
-            "/panel/orm/models/item/import/preview",
+            "/admin/orm/models/item/import/preview",
             files={"file": ("items.csv", csv_data, "text/csv")},
             data={"fields": ["id", "name", "description"]},
         )
@@ -497,7 +497,7 @@ class TestExportImportWizards:
         assert body["rows"][0]["id"] == "1"
 
         resp = self.client.post(
-            "/panel/orm/models/item/import/run",
+            "/admin/orm/models/item/import/run",
             json={"token": token, "fields": ["id", "name", "description"]},
         )
         assert resp.status_code == 200
@@ -523,14 +523,14 @@ class TestExportImportWizards:
             f"{existing.id + 1},two,newdesc\n"
         )
         resp_preview = self.client.post(
-            "/panel/orm/models/item/import/preview",
+            "/admin/orm/models/item/import/preview",
             files={"file": ("items.csv", csv_data, "text/csv")},
             data={"fields": ["id", "name", "description"]},
         )
         assert resp_preview.status_code == 200
         token = resp_preview.json()["token"]
         resp_run = self.client.post(
-            "/panel/orm/models/item/import/run",
+            "/admin/orm/models/item/import/run",
             json={"token": token, "fields": ["id", "name", "description"]},
         )
         assert resp_run.status_code == 200

--- a/tests/test_inlines.py
+++ b/tests/test_inlines.py
@@ -110,7 +110,7 @@ class TestInlineAdmin:
     def test_get_inlines_returns_metadata(self) -> None:
         parent = asyncio.run(Parent.create(name="p1"))
         asyncio.run(Child.create(parent=parent, name="c1"))
-        resp = self.client.get(f"/panel/orm/models/parent/{parent.id}/_inlines")
+        resp = self.client.get(f"/admin/orm/models/parent/{parent.id}/_inlines")
         assert resp.status_code == 200
         spec = resp.json()[0]
         assert spec["app"] == Parent.__module__.split(".")[0]
@@ -122,7 +122,7 @@ class TestInlineAdmin:
     def test_force_fk_header_on_create(self) -> None:
         parent = asyncio.run(Parent.create(name="p2"))
         resp = self.client.post(
-            "/panel/orm/models/child",
+            "/admin/orm/models/child",
             json={"name": "forced", "parent": 0},
             headers={"X-Force-FK-parent": str(parent.id)},
         )
@@ -137,21 +137,21 @@ class TestInlineAdmin:
 
     def test_inline_badge_updates_after_add_delete(self) -> None:
         parent = asyncio.run(Parent.create(name="p3"))
-        resp = self.client.get(f"/panel/orm/models/parent/{parent.id}/_inlines")
+        resp = self.client.get(f"/admin/orm/models/parent/{parent.id}/_inlines")
         assert resp.status_code == 200
         assert resp.json()[0]["count"] == 0
         resp_add = self.client.post(
-            "/panel/orm/models/child",
+            "/admin/orm/models/child",
             json={"name": "c1"},
             headers={"X-Force-FK-parent": str(parent.id)},
         )
         assert resp_add.status_code == 200
         child_id = resp_add.json()["id"]
-        resp = self.client.get(f"/panel/orm/models/parent/{parent.id}/_inlines")
+        resp = self.client.get(f"/admin/orm/models/parent/{parent.id}/_inlines")
         assert resp.json()[0]["count"] == 1
-        resp_del = self.client.delete(f"/panel/orm/models/child/{child_id}")
+        resp_del = self.client.delete(f"/admin/orm/models/child/{child_id}")
         assert resp_del.status_code == 200
-        resp = self.client.get(f"/panel/orm/models/parent/{parent.id}/_inlines")
+        resp = self.client.get(f"/admin/orm/models/parent/{parent.id}/_inlines")
         assert resp.json()[0]["count"] == 0
 
 

--- a/tests/test_settings_export.py
+++ b/tests/test_settings_export.py
@@ -85,7 +85,7 @@ class TestSettingsExport:
     def test_export_run_available(self) -> None:
         payload = {"scope": {"type": "ids", "ids": []}}
         resp = self.client.post(
-            "/panel/settings/admin/adminuser/export/run", json=payload
+            "/admin/settings/admin/adminuser/export/run", json=payload
         )
         assert resp.status_code == 200
         assert "token" in resp.json()


### PR DESCRIPTION
## Summary
- update the default admin prefix to `/admin` in core settings and the example configuration
- align tests and documentation with the new default prefix and highlight the security recommendation to customize it

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ecd49d747883308052821a82324b93