### PR TITLE
Add router scaffold to project initializer config templates

### DIFF
--- a/freeadmin/utils/cli/project_initializer.py
+++ b/freeadmin/utils/cli/project_initializer.py
@@ -17,6 +17,9 @@ from typing import Dict, Iterable
 from .reporting import CreationReport
 
 
+ROUTER_TEMPLATE_CLASS_NAME = "ProjectRouterBinder"
+
+
 class PackageInitializer:
     """Create ``__init__`` markers for project package directories."""
 
@@ -50,6 +53,10 @@ class ConfigTemplateProvider:
             "main.py": self._main_template().format(project_name=self._project_name),
             "orm.py": self._orm_template().format(project_name=self._project_name),
             "settings.py": self._settings_template().format(project_name=self._project_name),
+            "routers.py": self._routers_template().format(
+                project_name=self._project_name,
+                router_class=ROUTER_TEMPLATE_CLASS_NAME,
+            ),
         }
 
     def _main_template(self) -> str:
@@ -120,6 +127,50 @@ class ProjectSettings(BaseSettings):
 
 
 settings = ProjectSettings()
+
+
+# The End
+
+'''
+
+    def _routers_template(self) -> str:
+        return '''# -*- coding: utf-8 -*-
+"""
+routers
+
+Routing helpers for {project_name}.
+"""
+
+from __future__ import annotations
+
+from typing import Type
+
+from fastapi import FastAPI
+
+from freeadmin.core.site import AdminSite
+from freeadmin.router import AdminRouter
+
+
+class {router_class}:
+    """Mount the FreeAdmin router for {project_name}."""
+
+    def __init__(
+        self,
+        *,
+        admin_router_cls: Type[AdminRouter] = AdminRouter,
+    ) -> None:
+        """Store the admin router class used for mounting."""
+
+        self._admin_router_cls = admin_router_cls
+
+    def mount(self, app: FastAPI, site: AdminSite) -> None:
+        """Attach the admin router for ``site`` onto ``app``."""
+
+        admin_router = self._admin_router_cls(site)
+        admin_router.mount(app)
+
+
+__all__ = ["{router_class}"]
 
 
 # The End

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -13,7 +13,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from freeadmin.utils.cli.project_initializer import ProjectInitializer
+from freeadmin.utils.cli.project_initializer import (
+    ProjectInitializer,
+    ROUTER_TEMPLATE_CLASS_NAME,
+)
 
 
 class TestProjectInitializerConfigTemplates:
@@ -27,10 +30,14 @@ class TestProjectInitializerConfigTemplates:
 
         main_content = (config_dir / "main.py").read_text(encoding="utf-8")
         orm_content = (config_dir / "orm.py").read_text(encoding="utf-8")
+        routers_path = config_dir / "routers.py"
+        assert routers_path.exists()
+        routers_content = routers_path.read_text(encoding="utf-8")
         settings_content = (config_dir / "settings.py").read_text(encoding="utf-8")
 
         assert "ApplicationFactory" in main_content
         assert "ORMSettings" in orm_content
+        assert ROUTER_TEMPLATE_CLASS_NAME in routers_content
         assert "ProjectSettings" in settings_content
 
 


### PR DESCRIPTION
## Summary
- add a configurable routers.py template that provides the ProjectRouterBinder helper
- expose the router template class name for reuse and include __all__ metadata
- extend the CLI init test to ensure routers.py is generated with the expected class

## Testing
- pytest tests/test_cli_init.py

------
https://chatgpt.com/codex/tasks/task_e_68ed0bfb3b188330a3abcec65baf2a03