### PR TITLE
Fix router template aggregator naming

### DIFF
--- a/freeadmin/utils/cli/project_initializer.py
+++ b/freeadmin/utils/cli/project_initializer.py
@@ -17,7 +17,7 @@ from typing import Dict, Iterable
 from .reporting import CreationReport
 
 
-ROUTER_TEMPLATE_CLASS_NAME = "ProjectRouterBinder"
+ROUTER_TEMPLATE_CLASS_NAME = "ProjectRouterAggregator"
 
 
 class PackageInitializer:


### PR DESCRIPTION
## Summary
- update the router template class name used by the project initializer to the expected ProjectRouterAggregator

## Testing
- pytest tests/test_cli_init.py

------
https://chatgpt.com/codex/tasks/task_e_68ed24267cb48330989ce5e6ddb70b1c