### PR TITLE
Fix example app router mounting and add smoke test

### DIFF
--- a/example/config/main.py
+++ b/example/config/main.py
@@ -63,7 +63,7 @@ class ExampleApplication:
             adapter=self._orm.adapter_name,
             packages=discovery_packages,
         )
-        self._routers.attach_to(self._app)
+        self._routers.mount(self._app)
         return self._app
 
     @property

--- a/tests/test_example_application.py
+++ b/tests/test_example_application.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""
+test_example_application
+
+Smoke tests that validate the example application setup.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from __future__ import annotations
+
+from example.config.main import ExampleApplication
+
+
+class TestExampleApplicationSmoke:
+    """Verify that the example application mounts the admin router."""
+
+    def test_admin_router_mounted(self) -> None:
+        """Ensure configuring the example attaches the admin site to the app."""
+
+        application = ExampleApplication()
+        app = application.configure()
+
+        assert getattr(app.state, "admin_site", None) is not None
+
+
+# The End
+


### PR DESCRIPTION
## Summary
- call `mount()` on the example admin router during application configuration
- add a smoke test that instantiates the example app and verifies the admin router is attached

## Testing
- pytest tests/test_example_application.py

------
https://chatgpt.com/codex/tasks/task_e_68ed2e79dd58833090c297871d7cb4f1