### PR TITLE
Implement startup lifecycle for discovered app configs

### DIFF
--- a/freeadmin/boot.py
+++ b/freeadmin/boot.py
@@ -125,6 +125,11 @@ class BootManager:
         admin_hub.init_app(app, packages=packages)
 
         @app.on_event("startup")
+        async def _start_application_configs() -> None:
+            hub_ref = self._ensure_hub()
+            await hub_ref.start_app_configs()
+
+        @app.on_event("startup")
         async def _finalize_admin_site() -> None:
             hub_ref = self._ensure_hub()
             await hub_ref.admin_site.finalize()

--- a/tests/sampleapp/app.py
+++ b/tests/sampleapp/app.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""Test application configuration used in discovery tests."""
+
+from __future__ import annotations
+
+from freeadmin.core.app import AppConfig
+
+
+class SampleAppConfig(AppConfig):
+    """Track lifecycle calls for verification in the test-suite."""
+
+    app_label = "sampleapp"
+    name = "tests.sampleapp"
+
+    def __init__(self) -> None:
+        """Initialize mutable counters for startup assertions."""
+
+        super().__init__()
+        self.ready_calls = 0
+
+    async def startup(self) -> None:
+        """Increment invocation counter to mark lifecycle activation."""
+
+        self.ready_calls += 1
+
+
+default = SampleAppConfig()
+
+__all__ = ["SampleAppConfig", "default"]
+
+
+# The End

--- a/tests/test_example_application.py
+++ b/tests/test_example_application.py
@@ -11,7 +11,13 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
 from example.config.main import ExampleApplication
+from tests.sampleapp.app import default as sample_app_config
 
 
 class TestExampleApplicationSmoke:
@@ -24,6 +30,35 @@ class TestExampleApplicationSmoke:
         app = application.configure()
 
         assert getattr(app.state, "admin_site", None) is not None
+
+
+class TestExampleApplicationStartup:
+    """Ensure application configs execute startup hooks during boot."""
+
+    @pytest.mark.asyncio
+    async def test_app_config_startup_called(self) -> None:
+        """Verify AppConfig.startup executes when FastAPI starts up."""
+
+        sample_app_config.ready_calls = 0
+        application = ExampleApplication()
+        application.register_packages(["tests.sampleapp"])
+        app = application.configure()
+
+        boot_manager = application.boot_manager
+        hub = boot_manager._ensure_hub()
+        hub.admin_site.finalize = AsyncMock()
+        hub.admin_site.cards.start_publishers = AsyncMock()
+        hub.admin_site.cards.shutdown_publishers = AsyncMock()
+        boot_manager._config = SimpleNamespace(
+            ensure_seed=AsyncMock(),
+            reload=AsyncMock(),
+        )
+
+        await app.router.startup()
+        try:
+            assert sample_app_config.ready_calls == 1
+        finally:
+            await app.router.shutdown()
 
 
 # The End


### PR DESCRIPTION
## Summary
- ensure discovery loads application configs and returns them to callers
- retain discovered configs in the hub and invoke their ready hooks during FastAPI startup
- add a regression test application that verifies AppConfig.startup runs once the app starts

## Testing
- pytest tests/test_example_application.py

------
https://chatgpt.com/codex/tasks/task_e_68ed2fd1b5a08330a5451ffb504a36e9