### PR TITLE
Refactor boot manager into package modules

### DIFF
--- a/freeadmin/boot/__init__.py
+++ b/freeadmin/boot/__init__.py
@@ -1,0 +1,3 @@
+from .manager import BootManager, admin
+
+__all__ = ["BootManager", "admin"]

--- a/freeadmin/boot/collector.py
+++ b/freeadmin/boot/collector.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""
+boot.collector
+
+Utility helpers for bootstrapping the admin app.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+import pkgutil
+from typing import Callable, Iterable
+
+from ..core.app import AppConfig
+
+
+class AppConfigCollector:
+    """Discover application configs under supplied packages."""
+
+    def __init__(self, register: Callable[[AppConfig], None]) -> None:
+        self._register = register
+        self._visited: set[str] = set()
+
+    def collect(self, packages: Iterable[str]) -> None:
+        """Load app configs exposed by ``packages`` recursively."""
+
+        for package in packages:
+            self._walk_package(package)
+
+    def _walk_package(self, package_name: str) -> None:
+        if package_name in self._visited:
+            return
+        self._visited.add(package_name)
+        module = self._safe_import(package_name)
+        if module is None:
+            return
+        self._load_config(package_name)
+        module_path = getattr(module, "__path__", None)
+        if module_path is None:
+            return
+        prefix = module.__name__ + "."
+        for _, name, ispkg in pkgutil.walk_packages(module_path, prefix):
+            if ispkg:
+                self._walk_package(name)
+
+    def _load_config(self, module_path: str) -> None:
+        try:
+            config = AppConfig.load(module_path)
+        except (ModuleNotFoundError, AttributeError, TypeError, ValueError):
+            return
+        self._register(config)
+
+    @staticmethod
+    def _safe_import(module_name: str):
+        try:
+            return import_module(module_name)
+        except ModuleNotFoundError as exc:
+            if getattr(exc, "name", None) == module_name:
+                return None
+            raise
+
+
+# The End
+

--- a/freeadmin/boot/manager.py
+++ b/freeadmin/boot/manager.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-boot
+boot.manager
 
 Utility helpers for bootstrapping the admin app.
 
@@ -15,18 +15,21 @@ from fastapi import FastAPI
 from importlib import import_module
 import pkgutil
 from starlette.middleware.sessions import SessionMiddleware
-from typing import TYPE_CHECKING
+from typing import Iterable, TYPE_CHECKING
 
-from .adapters import BaseAdapter, registry
-from .conf import (
+from ..adapters import BaseAdapter, registry
+from ..conf import (
     FreeAdminSettings,
     current_settings,
     register_settings_observer,
 )
+from ..core.app import AppConfig
+from .collector import AppConfigCollector
+from .registry import ModelModuleRegistry
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .core.base import BaseModelAdmin
-    from .hub import AdminHub
+    from ..core.base import BaseModelAdmin
+    from ..hub import AdminHub
 
 
 class BootManager:
@@ -43,6 +46,7 @@ class BootManager:
         self._default_adapter_name = adapter_name
         self._adapter: BaseAdapter | None = None
         self._model_modules: set[str] = set()
+        self._model_registry = ModelModuleRegistry()
         self._hub: "AdminHub | None" = None
         self._settings = settings or current_settings()
         self._system_app: "SystemAppConfig | None" = None
@@ -50,12 +54,13 @@ class BootManager:
 
     def _ensure_config(self) -> None:
         if self._config is None:
-            from .core.settings.config import system_config
+            from ..core.settings.config import system_config
 
             self._config = system_config
 
     def _ensure_adapter(self) -> None:
         """Load default adapter if configured."""
+
         if self._adapter is None and self._default_adapter_name is not None:
             self._adapter = self._find_adapter(self._default_adapter_name)
             self._register_model_modules()
@@ -63,6 +68,7 @@ class BootManager:
     @property
     def adapter(self) -> BaseAdapter:
         """Return the ORM adapter, loading the default if necessary."""
+
         if self._adapter is None:
             name = self._default_adapter_name
             if name is None:
@@ -71,9 +77,24 @@ class BootManager:
             self._register_model_modules()
         return self._adapter
 
+    def load_app_config(self, module_path: str) -> AppConfig:
+        """Load and register an application configuration by module path."""
+
+        config = AppConfig.load(module_path)
+        self.register_app_config(config)
+        return config
+
+    def register_app_config(self, config: AppConfig) -> None:
+        """Register ``config`` and schedule its models for ORM registration."""
+
+        self._model_registry.register_config(config)
+        if self._adapter is not None:
+            self._register_model_modules()
+
     @property
     def user_model(self) -> type | None:
         """Return adapter's user model if available."""
+
         self._ensure_adapter()
         if self._adapter is None:
             return None
@@ -82,6 +103,7 @@ class BootManager:
     @property
     def model_modules(self) -> list[str]:
         """Return adapter model modules when configured."""
+
         self._ensure_adapter()
         if self._adapter is None:
             return []
@@ -89,7 +111,8 @@ class BootManager:
 
     def get_admin(self, target: str) -> "BaseModelAdmin | None":
         """Return registered admin instance for ``target``."""
-        from .hub import admin_site
+
+        from ..hub import admin_site
 
         try:
             app_label, model_name = target.split(".", 1)
@@ -107,8 +130,11 @@ class BootManager:
             self._adapter = self._find_adapter(adapter)
             self._register_model_modules()
 
-        from .middleware import AdminGuardMiddleware
-        from .core.settings import SettingsKey, system_config
+        if packages:
+            self._load_app_configs_from_packages(packages)
+
+        from ..middleware import AdminGuardMiddleware
+        from ..core.settings import SettingsKey, system_config
 
         app.add_middleware(AdminGuardMiddleware)
         session_cookie = system_config.get_cached(
@@ -152,24 +178,63 @@ class BootManager:
 
     def _find_adapter(self, name: str) -> BaseAdapter:
         """Discover and return an adapter instance by ``name``."""
-        package = import_module(".adapters", __package__)
+
+        package = import_module("..adapters", __package__)
         for _, modname, ispkg in pkgutil.iter_modules(package.__path__):
             if ispkg:
-                import_module(f".adapters.{modname}.adapter", __package__)
+                import_module(f"{package.__name__}.{modname}.adapter")
         return registry.get(name)
 
     def _register_model_modules(self) -> None:
         """Import adapter-provided model modules once."""
-        modules = getattr(self._adapter, "model_modules", [])
-        for dotted in modules:
-            if dotted not in self._model_modules:
-                import_module(dotted)
-                self._model_modules.add(dotted)
+
+        if self._adapter is None:
+            return
+        base_modules = getattr(self._adapter, "model_modules", [])
+        base_label = getattr(self._adapter, "system_app_label", "admin")
+        self._model_registry.register_base(base_label, base_modules)
+        for dotted in base_modules:
+            self._import_model_module(dotted)
+
+        if getattr(self._adapter, "name", None) == "tortoise":
+            from tortoise import Tortoise
+
+            if base_label in Tortoise.apps:
+                self._model_registry.mark_registered(base_label, base_modules)
+
+        for _, pending_modules in self._model_registry.iter_pending():
+            for dotted in pending_modules:
+                self._import_model_module(dotted)
+
+        self._register_models_with_adapter()
+
+    def _load_app_configs_from_packages(self, packages: Iterable[str]) -> None:
+        collector = AppConfigCollector(self.register_app_config)
+        collector.collect(packages)
+
+    def _register_models_with_adapter(self) -> None:
+        if self._adapter is None:
+            return
+        if getattr(self._adapter, "name", None) == "tortoise":
+            from tortoise import Tortoise
+
+            for app_label, modules in self._model_registry.iter_pending():
+                if not modules:
+                    continue
+                Tortoise.init_models(modules, app_label=app_label)
+                self._model_registry.mark_registered(app_label, modules)
+
+    def _import_model_module(self, dotted: str) -> None:
+        if dotted in self._model_modules:
+            return
+        import_module(dotted)
+        self._model_modules.add(dotted)
 
     def _ensure_hub(self) -> "AdminHub":
         """Return the cached admin hub instance, importing on first access."""
+
         if self._hub is None:
-            from .hub import hub as admin_hub
+            from ..hub import hub as admin_hub
 
             self._hub = admin_hub
         return self._hub
@@ -178,20 +243,23 @@ class BootManager:
         """Return the lazily instantiated system application configuration."""
 
         if self._system_app is None:
-            from .apps.system import SystemAppConfig
+            from ..apps.system import SystemAppConfig
 
             self._system_app = SystemAppConfig()
         return self._system_app
 
     def reset(self) -> None:
         """Restore manager to an uninitialized state."""
+
         self._config = None
         self._adapter = None
         self._model_modules.clear()
+        self._model_registry.clear()
         self._settings = current_settings()
 
     def _handle_settings_update(self, settings: FreeAdminSettings) -> None:
         """Refresh internal cache whenever global settings are reconfigured."""
+
         self._settings = settings
 
 

--- a/freeadmin/boot/registry.py
+++ b/freeadmin/boot/registry.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""
+boot.registry
+
+Utility helpers for bootstrapping the admin app.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from ..core.app import AppConfig
+
+
+class ModelModuleRegistry:
+    """Track adapter and app-specific model modules for registration."""
+
+    def __init__(self) -> None:
+        self._configs: dict[str, AppConfig] = {}
+        self._modules_by_label: dict[str, set[str]] = {}
+        self._registered: dict[str, set[str]] = {}
+
+    def register_base(self, app_label: str, modules: Iterable[str]) -> None:
+        """Record adapter-provided ``modules`` for ``app_label``."""
+
+        if not modules:
+            return
+        self._modules_by_label.setdefault(app_label, set()).update(modules)
+
+    def register_config(self, config: AppConfig) -> None:
+        """Store ``config`` and record its model modules."""
+
+        key = config.import_path
+        if key in self._configs:
+            return
+        self._configs[key] = config
+        modules = tuple(config.get_models_modules())
+        if not modules:
+            return
+        self._modules_by_label.setdefault(config.app_label, set()).update(modules)
+
+    def iter_pending(self) -> Iterable[tuple[str, list[str]]]:
+        """Yield app labels and modules that still require registration."""
+
+        for app_label, modules in self._modules_by_label.items():
+            registered = self._registered.get(app_label, set())
+            pending = sorted(module for module in modules if module not in registered)
+            if pending:
+                yield app_label, pending
+
+    def mark_registered(self, app_label: str, modules: Iterable[str]) -> None:
+        """Mark ``modules`` for ``app_label`` as registered."""
+
+        if not modules:
+            return
+        bucket = self._registered.setdefault(app_label, set())
+        bucket.update(modules)
+
+    def clear(self) -> None:
+        """Reset stored configuration and registration metadata."""
+
+        self._configs.clear()
+        self._modules_by_label.clear()
+        self._registered.clear()
+
+
+# The End
+

--- a/tests/sample_app/__init__.py
+++ b/tests/sample_app/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""sample_app
+
+Test application package exposing a minimal AppConfig."""
+
+from __future__ import annotations
+
+from .app import SampleAppConfig, default
+
+__all__ = ["SampleAppConfig", "default"]
+
+
+# The End

--- a/tests/sample_app/app.py
+++ b/tests/sample_app/app.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Application configuration used for BootManager registration tests."""
+
+from __future__ import annotations
+
+from freeadmin.core.app import AppConfig
+
+
+class SampleAppConfig(AppConfig):
+    """Expose models from the sample test application."""
+
+    app_label = "sample"
+    name = "tests.sample_app"
+    models = ("tests.sample_app.models",)
+
+
+default = SampleAppConfig()
+
+__all__ = ["SampleAppConfig", "default"]
+
+
+# The End

--- a/tests/sample_app/models.py
+++ b/tests/sample_app/models.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+"""Tortoise ORM models for the sample test application."""
+
+from __future__ import annotations
+
+from tortoise import fields
+from tortoise.models import Model
+
+
+class SampleNote(Model):
+    """Represent a simple note used to verify model registration."""
+
+    id = fields.IntField(pk=True)
+    title = fields.CharField(max_length=100)
+
+
+__all__ = ["SampleNote"]
+
+
+# The End

--- a/tests/test_boot_manager_model_registration.py
+++ b/tests/test_boot_manager_model_registration.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""Ensure BootManager registers custom application models with Tortoise."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from tortoise import Tortoise
+
+from freeadmin.boot import BootManager
+
+
+def test_boot_manager_registers_custom_models(monkeypatch) -> None:
+    """Ensure BootManager registers models from AppConfig only once."""
+
+    calls: List[Tuple[Tuple[str, ...], str]] = []
+    original_init_models = Tortoise.init_models
+
+    def _record(modules: List[str], app_label: str) -> None:
+        calls.append((tuple(modules), app_label))
+        original_init_models(modules, app_label)
+
+    monkeypatch.setattr(Tortoise, "init_models", _record)
+
+    boot = BootManager(adapter_name="tortoise")
+    boot.load_app_config("tests.sample_app")
+    _ = boot.adapter
+
+    sample_calls = [entry for entry in calls if entry[1] == "sample"]
+    assert sample_calls
+    assert "sample" in Tortoise.apps
+    assert "SampleNote" in Tortoise.apps["sample"]
+
+    boot.load_app_config("tests.sample_app")
+    sample_calls = [entry for entry in calls if entry[1] == "sample"]
+    assert len(sample_calls) == 1
+
+    boot.reset()
+    Tortoise.apps.pop("sample", None)
+
+
+# The End


### PR DESCRIPTION
## Summary
- reorganize the boot utilities into a package with dedicated manager, collector, and registry modules so BootManager remains focused while preserving the cached Tortoise registration flow
- re-export BootManager and the default admin instance from freeadmin.boot to maintain the public API surface

## Testing
- pytest tests/test_boot_manager_model_registration.py

------
https://chatgpt.com/codex/tasks/task_e_68ed34b6ea8883309f3e4022fdd19fce