### PR TITLE
Refine boot model registration orchestration

### DIFF
--- a/freeadmin/boot/__init__.py
+++ b/freeadmin/boot/__init__.py
@@ -1,0 +1,3 @@
+from .manager import BootManager, admin
+
+__all__ = ["BootManager", "admin"]

--- a/freeadmin/boot/collector.py
+++ b/freeadmin/boot/collector.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""
+boot.collector
+
+Utility helpers for bootstrapping the admin app.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+import pkgutil
+from typing import Callable, Iterable
+
+from ..core.app import AppConfig
+
+
+class AppConfigCollector:
+    """Discover application configs under supplied packages."""
+
+    def __init__(self, register: Callable[[AppConfig], None]) -> None:
+        self._register = register
+        self._visited: set[str] = set()
+
+    def collect(self, packages: Iterable[str]) -> None:
+        """Load app configs exposed by ``packages`` recursively."""
+
+        for package in packages:
+            self._walk_package(package)
+
+    def _walk_package(self, package_name: str) -> None:
+        if package_name in self._visited:
+            return
+        self._visited.add(package_name)
+        module = self._safe_import(package_name)
+        if module is None:
+            return
+        self._load_config(package_name)
+        module_path = getattr(module, "__path__", None)
+        if module_path is None:
+            return
+        prefix = module.__name__ + "."
+        for _, name, ispkg in pkgutil.walk_packages(module_path, prefix):
+            if ispkg:
+                self._walk_package(name)
+
+    def _load_config(self, module_path: str) -> None:
+        try:
+            config = AppConfig.load(module_path)
+        except (ModuleNotFoundError, AttributeError, TypeError, ValueError):
+            return
+        self._register(config)
+
+    @staticmethod
+    def _safe_import(module_name: str):
+        try:
+            return import_module(module_name)
+        except ModuleNotFoundError as exc:
+            if getattr(exc, "name", None) == module_name:
+                return None
+            raise
+
+
+# The End
+

--- a/freeadmin/boot/registry.py
+++ b/freeadmin/boot/registry.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+"""
+boot.registry
+
+Utility helpers for bootstrapping the admin app.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Iterable, TYPE_CHECKING
+
+from ..core.app import AppConfig
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..adapters import BaseAdapter
+
+
+class ModelModuleRegistry:
+    """Track adapter and app-specific model modules for registration."""
+
+    def __init__(self) -> None:
+        self._configs: dict[str, AppConfig] = {}
+        self._modules_by_label: dict[str, set[str]] = {}
+        self._registered: dict[str, set[str]] = {}
+
+    def register_base(self, app_label: str, modules: Iterable[str]) -> None:
+        """Record adapter-provided ``modules`` for ``app_label``."""
+
+        if not modules:
+            return
+        self._modules_by_label.setdefault(app_label, set()).update(modules)
+
+    def register_config(self, config: AppConfig) -> None:
+        """Store ``config`` and record its model modules."""
+
+        key = config.import_path
+        if key in self._configs:
+            return
+        self._configs[key] = config
+        modules = tuple(config.get_models_modules())
+        if not modules:
+            return
+        self._modules_by_label.setdefault(config.app_label, set()).update(modules)
+
+    def iter_pending(self) -> Iterable[tuple[str, list[str]]]:
+        """Yield app labels and modules that still require registration."""
+
+        for app_label, modules in self._modules_by_label.items():
+            registered = self._registered.get(app_label, set())
+            pending = sorted(module for module in modules if module not in registered)
+            if pending:
+                yield app_label, pending
+
+    def mark_registered(self, app_label: str, modules: Iterable[str]) -> None:
+        """Mark ``modules`` for ``app_label`` as registered."""
+
+        if not modules:
+            return
+        bucket = self._registered.setdefault(app_label, set())
+        bucket.update(modules)
+
+    def clear(self) -> None:
+        """Reset stored configuration and registration metadata."""
+
+        self._configs.clear()
+        self._modules_by_label.clear()
+        self._registered.clear()
+
+
+class ModelRegistrar:
+    """Coordinate model discovery and adapter-specific registration."""
+
+    def __init__(self) -> None:
+        self._registry = ModelModuleRegistry()
+        self._imported_modules: set[str] = set()
+
+    def add_adapter(self, adapter: "BaseAdapter") -> None:
+        """Collect adapter-provided modules and import them once."""
+
+        base_modules = getattr(adapter, "model_modules", [])
+        base_label = getattr(adapter, "system_app_label", "admin")
+        self._registry.register_base(base_label, base_modules)
+        for dotted in base_modules:
+            self._import_module(dotted)
+        if getattr(adapter, "name", None) == "tortoise":
+            from tortoise import Tortoise
+
+            if base_label in Tortoise.apps:
+                self._registry.mark_registered(base_label, base_modules)
+
+    def add_config(self, config: AppConfig) -> None:
+        """Store ``config`` metadata and stage its models for registration."""
+
+        self._registry.register_config(config)
+
+    def sync_with_adapter(self, adapter: "BaseAdapter") -> None:
+        """Register pending modules with ``adapter`` when required."""
+
+        pending = list(self._registry.iter_pending())
+        for _, modules in pending:
+            for dotted in modules:
+                self._import_module(dotted)
+
+        if getattr(adapter, "name", None) == "tortoise":
+            from tortoise import Tortoise
+
+            for app_label, modules in pending:
+                if not modules:
+                    continue
+                Tortoise.init_models(modules, app_label=app_label)
+                self._registry.mark_registered(app_label, modules)
+
+    def clear(self) -> None:
+        """Reset cached import and registration metadata."""
+
+        self._registry.clear()
+        self._imported_modules.clear()
+
+    def _import_module(self, dotted_path: str) -> None:
+        if dotted_path in self._imported_modules:
+            return
+        import_module(dotted_path)
+        self._imported_modules.add(dotted_path)
+
+
+# The End
+

--- a/tests/sample_app/__init__.py
+++ b/tests/sample_app/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""sample_app
+
+Test application package exposing a minimal AppConfig."""
+
+from __future__ import annotations
+
+from .app import SampleAppConfig, default
+
+__all__ = ["SampleAppConfig", "default"]
+
+
+# The End

--- a/tests/sample_app/app.py
+++ b/tests/sample_app/app.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Application configuration used for BootManager registration tests."""
+
+from __future__ import annotations
+
+from freeadmin.core.app import AppConfig
+
+
+class SampleAppConfig(AppConfig):
+    """Expose models from the sample test application."""
+
+    app_label = "sample"
+    name = "tests.sample_app"
+    models = ("tests.sample_app.models",)
+
+
+default = SampleAppConfig()
+
+__all__ = ["SampleAppConfig", "default"]
+
+
+# The End

--- a/tests/sample_app/models.py
+++ b/tests/sample_app/models.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+"""Tortoise ORM models for the sample test application."""
+
+from __future__ import annotations
+
+from tortoise import fields
+from tortoise.models import Model
+
+
+class SampleNote(Model):
+    """Represent a simple note used to verify model registration."""
+
+    id = fields.IntField(pk=True)
+    title = fields.CharField(max_length=100)
+
+
+__all__ = ["SampleNote"]
+
+
+# The End

--- a/tests/test_boot_manager_model_registration.py
+++ b/tests/test_boot_manager_model_registration.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""Ensure BootManager registers custom application models with Tortoise."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from tortoise import Tortoise
+
+from freeadmin.boot import BootManager
+
+
+def test_boot_manager_registers_custom_models(monkeypatch) -> None:
+    """Ensure BootManager registers models from AppConfig only once."""
+
+    calls: List[Tuple[Tuple[str, ...], str]] = []
+    original_init_models = Tortoise.init_models
+
+    def _record(modules: List[str], app_label: str) -> None:
+        calls.append((tuple(modules), app_label))
+        original_init_models(modules, app_label)
+
+    monkeypatch.setattr(Tortoise, "init_models", _record)
+
+    boot = BootManager(adapter_name="tortoise")
+    boot.load_app_config("tests.sample_app")
+    _ = boot.adapter
+
+    sample_calls = [entry for entry in calls if entry[1] == "sample"]
+    assert sample_calls
+    assert "sample" in Tortoise.apps
+    assert "SampleNote" in Tortoise.apps["sample"]
+
+    boot.load_app_config("tests.sample_app")
+    sample_calls = [entry for entry in calls if entry[1] == "sample"]
+    assert len(sample_calls) == 1
+
+    boot.reset()
+    Tortoise.apps.pop("sample", None)
+
+
+# The End


### PR DESCRIPTION
## Summary
- encapsulate adapter and app model registration details inside a dedicated ModelRegistrar helper
- simplify BootManager by delegating module discovery and adapter synchronization to the registrar while preserving cached behavior

## Testing
- pytest tests/test_boot_manager_model_registration.py

------
https://chatgpt.com/codex/tasks/task_e_68ed34b6ea8883309f3e4022fdd19fce