### PR TITLE
Ensure admin app configs run during startup

### DIFF
--- a/freeadmin/boot/manager.py
+++ b/freeadmin/boot/manager.py
@@ -152,6 +152,7 @@ class BootManager:
         @app.on_event("startup")
         async def _finalize_admin_site() -> None:
             hub_ref = self._ensure_hub()
+            await hub_ref.start_app_configs()
             await hub_ref.admin_site.finalize()
             await hub_ref.admin_site.cards.start_publishers()
 


### PR DESCRIPTION
## Summary
- start discovered admin app configs during FastAPI startup before finalization

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ed3df6aea48330b654961fc220c6f4