### PR TITLE
Ensure example ORM lifecycle binds before boot init

### DIFF
--- a/example/config/main.py
+++ b/example/config/main.py
@@ -58,14 +58,14 @@ class ExampleApplication:
             "example.apps",
             "example.pages",
         ]
+        if not self._orm_events_bound:
+            self._orm_lifecycle.bind(self._app)
+            self._orm_events_bound = True
         self._boot.init(
             self._app,
             adapter=self._orm.adapter_name,
             packages=discovery_packages,
         )
-        if not self._orm_events_bound:
-            self._orm_lifecycle.bind(self._app)
-            self._orm_events_bound = True
         self._routers.mount(self._app)
         return self._app
 


### PR DESCRIPTION
## Summary
- bind the example ORM lifecycle before invoking the boot manager so startup events execute in the correct order

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ed42605a1c8330a29d7e65e7e0cef9