### PR TITLE
Improve admin router helper template

### DIFF
--- a/freeadmin/utils/cli/project_initializer.py
+++ b/freeadmin/utils/cli/project_initializer.py
@@ -237,16 +237,16 @@ Routing helpers for {project_name}.
 
 from __future__ import annotations
 
-from typing import Type
+from typing import Optional, Type
 
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 
 from freeadmin.core.site import AdminSite
 from freeadmin.router import AdminRouter
 
 
 class {router_class}:
-    """Mount the FreeAdmin router for {project_name}."""
+    """Manage mounting the FreeAdmin router for {project_name}."""
 
     def __init__(
         self,
@@ -256,15 +256,58 @@ class {router_class}:
         """Store the admin router class used for mounting."""
 
         self._admin_router_cls = admin_router_cls
+        self._admin_router: Optional[AdminRouter] = None
+        self._router: Optional[APIRouter] = None
+        self._site: Optional[AdminSite] = None
 
-    def mount(self, app: FastAPI, site: AdminSite) -> None:
-        """Attach the admin router for ``site`` onto ``app``."""
+    def mount(self, app: FastAPI, site: AdminSite) -> APIRouter:
+        """Attach the admin router for ``site`` onto ``app`` once."""
 
-        admin_router = self._admin_router_cls(site)
-        admin_router.mount(app)
+        router = self.get_admin_router(site)
+        if getattr(app.state, "admin_site", None) is site:
+            return router
+
+        admin_router = self._ensure_admin_router(site)
+        app.state.admin_site = site
+        app.include_router(router, prefix=admin_router.prefix)
+        provider = admin_router._provider
+        provider.mount_static(app, admin_router.prefix)
+        provider.mount_favicon(app)
+        provider.mount_media(app)
+        return router
+
+    def get_admin_router(self, site: AdminSite) -> APIRouter:
+        """Return a cached admin router for the given ``site``."""
+
+        admin_router = self._ensure_admin_router(site)
+        if self._router is not None:
+            return self._router
+
+        if site.templates is None:
+            site.templates = admin_router._provider.get_templates()
+        self._router = site.build_router(admin_router._provider)
+        return self._router
+
+    def _ensure_admin_router(self, site: AdminSite) -> AdminRouter:
+        """Instantiate or reuse the admin router for ``site``."""
+
+        if self._admin_router is None or self._site is not site:
+            self._site = site
+            self._router = None
+            self._admin_router = self._admin_router_cls(site)
+        return self._admin_router
 
 
-__all__ = ["{router_class}"]
+_ROUTER_AGGREGATOR = {router_class}()
+
+
+def get_admin_router(site: AdminSite) -> APIRouter:
+    """Return the admin router for ``site`` using the shared aggregator."""
+
+    return _ROUTER_AGGREGATOR.get_admin_router(site)
+
+
+__all__ = ["{router_class}", "get_admin_router"]
 
 
 # The End

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -42,6 +42,8 @@ class TestProjectInitializerConfigTemplates:
         assert "ORMSettings" in orm_content
         assert "ORMLifecycle" in orm_content
         assert ROUTER_TEMPLATE_CLASS_NAME in routers_content
+        assert "def get_admin_router" in routers_content
+        assert "_ROUTER_AGGREGATOR" in routers_content
         assert "ProjectSettings" in settings_content
         assert "project_title" in settings_content
 


### PR DESCRIPTION
## Summary
- extend the generated routers.py template with a reusable ProjectRouterAggregator that caches the admin router and exposes a module-level get_admin_router helper
- update the CLI init test to assert that the routers template provides the new helper infrastructure
- refresh the installation guide to explain the helper workflow and show how to mount the admin router without remounting

## Testing
- pytest tests/test_cli_init.py

------
https://chatgpt.com/codex/tasks/task_e_68ed48904c98833084c22544d2405fba