### PR TITLE
Document adapter registry usage in boot guide

### DIFF
--- a/docs/admin/boot.md
+++ b/docs/admin/boot.md
@@ -8,19 +8,29 @@ built-in pages and mounts the admin site onto the ASGI application.
 
 ```python
 from fastapi import FastAPI
-from freeadmin.boot import admin
+from freeadmin.adapters import registry
+from freeadmin.boot import BootManager
 from my_project.adapters import MyAdapter
 
 app = FastAPI()
-admin.init(app, adapter=MyAdapter(), packages=["apps", "contrib", "core"])
+
+# Register the adapter instance so BootManager can retrieve it by name.
+registry.register(MyAdapter())
+
+boot = BootManager(adapter_name="my_adapter")
+boot.init(app, packages=["apps", "contrib", "core"])
 
 ```
 
 ## Adapter selection
 
-Provide the database backend via the ``adapter`` keyword. Supply any object
-implementing the adapter protocol, and ``BootManager`` will resolve it at
-startup and apply the required configuration.
+Provide the database backend via the ``adapter_name`` keyword (for example
+``adapter_name="tortoise"`` for the bundled Tortoise ORM integration). Supply
+your own adapter by creating an instance that implements the adapter protocol
+and registering it with ``freeadmin.adapters.registry`` before referencing the
+name in ``BootManager``. Existing adapter instances should be registered with
+the registry rather than passed directly to ``BootManager.init`` so they can be
+reused across the runtime.
 
 ## BootManager responsibilities
 


### PR DESCRIPTION
## Summary
- update the boot documentation to demonstrate registering adapters and passing adapter names to BootManager
- clarify that custom adapters must be added to the registry before BootManager can resolve them
- note that existing adapter instances should be registered instead of being passed directly to BootManager.init

## Testing
- mkdocs build *(fails: MkDocs encountered an error parsing mkdocs.yml)*

------
https://chatgpt.com/codex/tasks/task_e_68ed5588d7b08330ac0f79ae580d010c