### PR TITLE
Handle config startup operational errors

### DIFF
--- a/freeadmin/core/settings/config.py
+++ b/freeadmin/core/settings/config.py
@@ -11,13 +11,36 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 
+import importlib.util
 import logging
-from typing import Any
+import sqlite3
+from typing import Any, Tuple
+
+from tortoise import exceptions as tortoise_exceptions
 
 from .defaults import DEFAULT_SETTINGS
 from .keys import SettingsKey
 from ...boot import admin as boot_admin
 SystemSetting = boot_admin.adapter.system_setting_model
+
+if importlib.util.find_spec("asyncpg") is not None:
+    from asyncpg import exceptions as asyncpg_exceptions
+
+    ASYNCPG_ERRORS: Tuple[type[BaseException], ...] = (
+        asyncpg_exceptions.UndefinedTableError,
+    ) if hasattr(asyncpg_exceptions, "UndefinedTableError") else ()
+else:
+    ASYNCPG_ERRORS = ()
+
+TORTOISE_OPERATIONAL_ERRORS: Tuple[type[BaseException], ...] = (
+    tortoise_exceptions.OperationalError,
+)
+if hasattr(tortoise_exceptions, "DBOperationalError"):
+    TORTOISE_OPERATIONAL_ERRORS += (tortoise_exceptions.DBOperationalError,)
+
+DATABASE_OPERATION_ERRORS: Tuple[type[BaseException], ...] = (
+    sqlite3.OperationalError,
+) + TORTOISE_OPERATIONAL_ERRORS + ASYNCPG_ERRORS
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +72,16 @@ class SystemConfig:
         Inserts any missing keys from :data:`DEFAULT_SETTINGS` and reloads the
         cache afterwards.
         """
+
+        try:
+            await self._seed_defaults()
+        except DATABASE_OPERATION_ERRORS as exc:
+            logger.warning(
+                "Skipping system configuration seed due to database error: %s", exc
+            )
+
+    async def _seed_defaults(self) -> None:
+        """Perform the default seeding workflow within a transaction."""
 
         async with self.adapter.in_transaction():
             # migrate legacy page-type keys if present
@@ -90,18 +123,23 @@ class SystemConfig:
     async def reload(self) -> None:
         """Reload settings from the database into the in-memory cache."""
 
-        self._cache.clear()
-        type_map = {k.value: t for k, (_, t) in DEFAULT_SETTINGS.items()}
-        qs = self.adapter.values(self.adapter.all(SystemSetting), "key", "value")
-        for record in await self.adapter.fetch_all(qs):
-            key = record["key"]
-            value_type = type_map.get(key, "string")
-            self._cache[key] = self._cast(record["value"], value_type)
+        try:
+            self._cache.clear()
+            type_map = {k.value: t for k, (_, t) in DEFAULT_SETTINGS.items()}
+            qs = self.adapter.values(self.adapter.all(SystemSetting), "key", "value")
+            for record in await self.adapter.fetch_all(qs):
+                key = record["key"]
+                value_type = type_map.get(key, "string")
+                self._cache[key] = self._cast(record["value"], value_type)
 
-        # Ensure defaults for any keys still missing (in case DB lacked them)
-        for key_enum, (value, value_type) in DEFAULT_SETTINGS.items():
-            key = key_enum.value
-            self._cache.setdefault(key, self._cast(value, value_type))
+            # Ensure defaults for any keys still missing (in case DB lacked them)
+            for key_enum, (value, value_type) in DEFAULT_SETTINGS.items():
+                key = key_enum.value
+                self._cache.setdefault(key, self._cast(value, value_type))
+        except DATABASE_OPERATION_ERRORS as exc:
+            logger.warning(
+                "Skipping system configuration reload due to database error: %s", exc
+            )
 
     def get_cached(self, key: SettingsKey | str, default: Any | None = None) -> Any:
         """Return ``key`` value directly from the in-memory cache.
@@ -198,6 +236,9 @@ class SystemConfig:
 # Module-level singleton ------------------------------------------------------
 
 system_config = SystemConfig()
+
+
+# The End
 
 __all__ = ["SystemConfig", "system_config"]
 

--- a/tests/test_system_config_startup.py
+++ b/tests/test_system_config_startup.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+"""Tests ensuring system configuration startup is resilient to DB errors."""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from tortoise.exceptions import OperationalError
+
+from freeadmin.core.settings import config as config_module
+
+
+class _AdapterTransaction:
+    def __init__(self, adapter: "FailingAdapter") -> None:
+        self._adapter = adapter
+
+    async def __aenter__(self) -> "FailingAdapter":
+        return self._adapter
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class FailingAdapter:
+    """Adapter that raises the configured ``error`` for every DB operation."""
+
+    def __init__(self, error: BaseException) -> None:
+        self.error = error
+
+    def in_transaction(self) -> _AdapterTransaction:
+        return _AdapterTransaction(self)
+
+    async def get_or_none(self, *args: Any, **kwargs: Any) -> Any:
+        raise self.error
+
+    async def exists(self, *args: Any, **kwargs: Any) -> bool:
+        raise self.error
+
+    async def delete(self, *args: Any, **kwargs: Any) -> None:
+        raise self.error
+
+    async def save(self, *args: Any, **kwargs: Any) -> None:
+        raise self.error
+
+    async def create(self, *args: Any, **kwargs: Any) -> Any:
+        raise self.error
+
+    def filter(self, *args: Any, **kwargs: Any) -> Any:
+        return SimpleNamespace()
+
+    def all(self, *args: Any, **kwargs: Any) -> Any:
+        raise self.error
+
+    def values(self, *args: Any, **kwargs: Any) -> Any:
+        raise self.error
+
+    async def fetch_all(self, *args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        raise self.error
+
+
+@pytest.mark.asyncio
+async def test_ensure_seed_handles_operational_error(monkeypatch, caplog) -> None:
+    config = config_module.SystemConfig()
+    error = OperationalError("missing table system_settings")
+    adapter = FailingAdapter(error)
+    monkeypatch.setattr(
+        config_module.SystemConfig, "adapter", property(lambda self: adapter)
+    )
+
+    caplog.set_level(logging.WARNING, logger=config_module.logger.name)
+
+    await config.ensure_seed()
+
+    assert "Skipping system configuration seed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_reload_handles_operational_error(monkeypatch, caplog) -> None:
+    config = config_module.SystemConfig()
+    error = OperationalError("missing table system_settings")
+    adapter = FailingAdapter(error)
+    monkeypatch.setattr(
+        config_module.SystemConfig, "adapter", property(lambda self: adapter)
+    )
+
+    caplog.set_level(logging.WARNING, logger=config_module.logger.name)
+
+    await config.reload()
+
+    assert "Skipping system configuration reload" in caplog.text
+
+
+# The End


### PR DESCRIPTION
## Summary
- guard system configuration seeding and reload against database operational errors
- add private helper for seeding defaults and log warnings when failures occur
- cover the new behaviour with tests using a failing adapter stub

## Testing
- pytest tests/test_system_config_startup.py

------
https://chatgpt.com/codex/tasks/task_e_68ee12ce8a2c8330a313896a767c0d72