### PR TITLE
Introduce reusable ORMConfig base class

### DIFF
--- a/docs/first-run-example.md
+++ b/docs/first-run-example.md
@@ -24,10 +24,14 @@ app = application.configure()
   metadata, the admin path (`/admin`), and the list of installed apps. Its
   `describe()` helper returns a concise summary that is useful for debugging
   configuration during development.
-* `ExampleORMConfig` (`example/config/orm.py`) declares which adapter to use
-  (`tortoise` by default) together with the database DSN. The configuration is
-  intentionally simple and points to an in-memory SQLite database so you can
-  explore the admin without provisioning external infrastructure.
+* `ExampleORMConfig` (`example/config/orm.py`) subclasses the shared
+  `freeadmin.orm.ORMConfig` helper. The base class exposes `describe()` and
+  `create_lifecycle()` methods out of the box, so the example configuration only
+  needs to list the project modules that contain models. Built-in adapter
+  modules are merged automatically which keeps the configuration declarative and
+  free from custom lifecycle code. The DSN defaults to an in-memory SQLite
+  database so you can explore the admin without provisioning external
+  infrastructure.
 * The `BootManager` binds the FastAPI app and discovers admin resources in the
   `example.apps` and `example.pages` packages. You can register additional
   packages before calling `configure()` if you want to experiment with your own
@@ -41,6 +45,21 @@ app = application.configure()
   ])
   app = application.configure()
   ```
+
+  The same pattern scales to your own projects. Subclass `ORMConfig` and provide
+  a module map to declare where your models live:
+
+  ```python
+  from freeadmin.orm import ORMConfig
+
+
+  class MyORMConfig(ORMConfig):
+      def __init__(self) -> None:
+          super().__init__(modules={"models": ["myproject.apps.blog.models"]})
+  ```
+
+  No extra lifecycle methods are required—the default implementation wires the
+  FastAPI startup and shutdown hooks for you.
 
 ## Launching the demo
 

--- a/example/config/main.py
+++ b/example/config/main.py
@@ -37,7 +37,7 @@ class ExampleApplication:
         self._settings = settings or ExampleSettings()
         self._orm = orm or ExampleORMConfig()
         self._orm_lifecycle: ExampleORMLifecycle = self._orm.create_lifecycle()
-        self._boot = BootManager(adapter_name=self._orm.adapter_name)
+        self._boot = BootManager(adapter_name=self._orm_lifecycle.adapter_name)
         self._app = FastAPI(title=self._settings.project_name)
         self._packages: List[str] = []
         self._routers = ExampleAdminRouters()
@@ -63,7 +63,7 @@ class ExampleApplication:
             self._orm_events_bound = True
         self._boot.init(
             self._app,
-            adapter=self._orm.adapter_name,
+            adapter=self._orm_lifecycle.adapter_name,
             packages=discovery_packages,
         )
         self._routers.mount(self._app)

--- a/freeadmin/orm/__init__.py
+++ b/freeadmin/orm/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+"""
+__init__
+
+ORM integration helpers.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from .config import ORMConfig, ORMLifecycle
+
+__all__ = ["ORMConfig", "ORMLifecycle"]
+
+# The End
+

--- a/freeadmin/orm/config.py
+++ b/freeadmin/orm/config.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+"""
+config
+
+Declarative ORM configuration helpers for FreeAdmin projects.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Dict, Iterable, List, Mapping, MutableMapping
+
+from fastapi import FastAPI
+from tortoise import Tortoise
+
+from ..adapters import registry
+
+
+class ORMLifecycle:
+    """Manage Tortoise ORM startup and shutdown hooks for FastAPI."""
+
+    def __init__(self, *, config: ORMConfig) -> None:
+        """Persist the configuration used to initialise the ORM."""
+
+        self._config = config
+
+    @property
+    def adapter_name(self) -> str:
+        """Return the name of the adapter that powers the ORM lifecycle."""
+
+        return self._config.adapter_name
+
+    @property
+    def modules(self) -> Dict[str, List[str]]:
+        """Return the modules mapping supplied to :func:`Tortoise.init`."""
+
+        return self._config.modules
+
+    async def startup(self) -> None:
+        """Initialise ORM connections when the FastAPI application boots."""
+
+        await Tortoise.init(
+            db_url=self._config.connection_dsn,
+            modules=self.modules,
+        )
+
+    async def shutdown(self) -> None:
+        """Tear down all ORM connections during FastAPI shutdown."""
+
+        await Tortoise.close_connections()
+
+    def bind(self, app: FastAPI) -> None:
+        """Attach lifecycle hooks to a FastAPI application instance."""
+
+        app.add_event_handler("startup", self.startup)
+        app.add_event_handler("shutdown", self.shutdown)
+
+
+class ORMConfig:
+    """Declarative container for ORM connection and discovery settings."""
+
+    lifecycle_class = ORMLifecycle
+
+    def __init__(
+        self,
+        *,
+        adapter_name: str = "tortoise",
+        dsn: str | None = None,
+        modules: Mapping[str, Iterable[str]] | None = None,
+    ) -> None:
+        """Store adapter label, connection string, and module declarations."""
+
+        self._adapter_name = adapter_name
+        self._dsn = dsn or "sqlite://:memory:"
+        self._project_modules = self._normalize_modules(modules or {})
+        self._modules = self._merge_adapter_modules(self._project_modules)
+
+    @property
+    def adapter_name(self) -> str:
+        """Return the name of the registered adapter powering the ORM."""
+
+        return self._adapter_name
+
+    @property
+    def connection_dsn(self) -> str:
+        """Return the database connection string used for ORM startup."""
+
+        return self._dsn
+
+    @property
+    def modules(self) -> Dict[str, List[str]]:
+        """Return the module mapping passed to :func:`Tortoise.init`."""
+
+        return deepcopy(self._modules)
+
+    def describe(self) -> dict[str, str]:
+        """Return a human-readable summary of the ORM configuration."""
+
+        return {"adapter": self._adapter_name, "dsn": self._dsn}
+
+    def create_lifecycle(self) -> ORMLifecycle:
+        """Instantiate an ORM lifecycle manager for FastAPI integration."""
+
+        return self.lifecycle_class(config=self)
+
+    def _normalize_modules(
+        self, modules: Mapping[str, Iterable[str]]
+    ) -> Dict[str, List[str]]:
+        normalized: Dict[str, List[str]] = {}
+        for label, values in modules.items():
+            normalized[label] = [str(module) for module in values]
+        return normalized
+
+    def _merge_adapter_modules(
+        self, modules: MutableMapping[str, List[str]]
+    ) -> Dict[str, List[str]]:
+        merged = deepcopy(modules)
+        adapter = registry.get(self._adapter_name)
+        adapter_modules = list(getattr(adapter, "model_modules", []))
+        project_models = merged.setdefault("models", [])
+        for module in adapter_modules:
+            if module not in project_models:
+                project_models.append(module)
+        return merged
+
+
+__all__ = ["ORMConfig", "ORMLifecycle"]
+
+# The End
+


### PR DESCRIPTION
## Summary
- add a reusable `ORMConfig` and `ORMLifecycle` implementation that merges adapter-provided modules with project modules
- refactor the example ORM configuration and bootstrap to build on the shared base helpers and keep lifecycle wiring declarative
- document the new configuration flow in the example walkthrough

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee1e7a24a0833086f1bf56ea917b79