### PR TITLE
Refine example configuration to use shared ORM lifecycle

### DIFF
--- a/example/config/main.py
+++ b/example/config/main.py
@@ -17,8 +17,9 @@ from typing import List
 from fastapi import FastAPI
 
 from freeadmin.boot import BootManager
+from freeadmin.orm import ORMLifecycle
 
-from .orm import ExampleORMConfig, ExampleORMLifecycle
+from .orm import ExampleORMConfig
 from .routers import ExampleAdminRouters
 from .settings import ExampleSettings
 
@@ -36,7 +37,7 @@ class ExampleApplication:
 
         self._settings = settings or ExampleSettings()
         self._orm = orm or ExampleORMConfig()
-        self._orm_lifecycle: ExampleORMLifecycle = self._orm.create_lifecycle()
+        self._orm_lifecycle: ORMLifecycle = self._orm.create_lifecycle()
         self._boot = BootManager(adapter_name=self._orm_lifecycle.adapter_name)
         self._app = FastAPI(title=self._settings.project_name)
         self._packages: List[str] = []

--- a/example/config/orm.py
+++ b/example/config/orm.py
@@ -41,7 +41,7 @@ class ExampleORMConfig(ORMConfig):
         default_modules: Dict[str, List[str]] = {
             "models": ["example.apps.demo.models"],
         }
-        if not modules:
+        if modules is None:
             return default_modules
         project_modules: Dict[str, List[str]] = {
             label: [str(value) for value in values]
@@ -55,9 +55,7 @@ class ExampleORMConfig(ORMConfig):
         return project_modules
 
 
-ExampleORMLifecycle = ORMLifecycle
-
-__all__ = ["ExampleORMConfig", "ExampleORMLifecycle", "ORMLifecycle"]
+__all__ = ["ExampleORMConfig", "ORMLifecycle"]
 
 # The End
 


### PR DESCRIPTION
## Summary
- expose the shared `ORMLifecycle` helper alongside `ORMConfig`, wiring Tortoise startup and shutdown hooks for FastAPI
- simplify the example ORM configuration to re-export the shared lifecycle helper without maintaining a bespoke alias
- update the example application bootstrap to depend on the package-level lifecycle class

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee26e5a7f88330acf39511b1744699