### PR TITLE
Refactor init scaffolding to declarative ORM config

### DIFF
--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -39,8 +39,9 @@ class TestProjectInitializerConfigTemplates:
         assert "self._boot.init" in main_content
         assert '"apps", "pages"' in main_content
         assert "self._orm_lifecycle.bind" in main_content
-        assert "ORMSettings" in orm_content
-        assert "ORMLifecycle" in orm_content
+        assert "from .orm import ORM" in main_content
+        assert "ORM_CONFIG" in orm_content
+        assert "ORM: ORMConfig = ORMConfig.build" in orm_content
         assert ROUTER_TEMPLATE_CLASS_NAME in routers_content
         assert "def get_admin_router" in routers_content
         assert "_ROUTER_AGGREGATOR" in routers_content


### PR DESCRIPTION
## Summary
- refactor the init scaffolding ORM template to declare adapter constants, module lists, and a reusable ORMConfig instance
- update the generated main module to consume the exported ORMConfig lifecycle instead of ORMSettings/ORMLifecycle classes
- refresh documentation and tests to describe the new declarative template structure

## Testing
- pytest tests/test_cli_init.py

------
https://chatgpt.com/codex/tasks/task_e_68ee44236d888330aaaa899b3d4d9db0