### PR TITLE
Fix example ORM config apps layout

### DIFF
--- a/example/config/orm.py
+++ b/example/config/orm.py
@@ -38,15 +38,15 @@ ORM_CONFIG: Dict[str, Dict[str, Any]] = {
     "connections": {
         "default": "sqlite://:memory:",
     },
-    "system": {
-        "models": list(SYSTEM_APP_MODULES),
-        "default_connection": "default",
-    },
-    "admin": {
-        "models": list(ADMIN_APP_MODULES),
-        "default_connection": "default",
-    },
     "apps": {
+        "system": {
+            "models": list(SYSTEM_APP_MODULES),
+            "default_connection": "default",
+        },
+        "admin": {
+            "models": list(ADMIN_APP_MODULES),
+            "default_connection": "default",
+        },
         "models": {
             "models": list(MODELS_APP_MODULES),
             "default_connection": "default",


### PR DESCRIPTION
## Summary
- nest the example system, admin, and project model declarations under the Tortoise ORM `apps` section so FreeAdmin startup can discover them

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ee45f14a908330a48219c19fd61825