### PR TITLE
Add application factory for FastAPI integration

### DIFF
--- a/freeadmin/__init__.py
+++ b/freeadmin/__init__.py
@@ -8,11 +8,12 @@ Author: Timur Kady
 Email: timurkady@yandex.com
 """
 
+from .application import ApplicationFactory
+from .conf import FreeAdminSettings, configure, current_settings
 from .core.base import BaseModelAdmin
 from .core.site import AdminSite
 from .meta import __version__
 from .router import AdminRouter
-from .conf import FreeAdminSettings, configure, current_settings
 
 # The End
 

--- a/freeadmin/application/__init__.py
+++ b/freeadmin/application/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+"""
+application
+
+Application assembly helpers for FreeAdmin projects.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from .factory import ApplicationFactory
+
+__all__ = ["ApplicationFactory"]
+
+
+# The End

--- a/freeadmin/application/factory.py
+++ b/freeadmin/application/factory.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+"""
+application.factory
+
+Factories for assembling FastAPI applications with FreeAdmin integration.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Iterable
+from inspect import Parameter, signature
+from typing import Any, Protocol, runtime_checkable
+
+from fastapi import FastAPI
+
+from ..boot import BootManager
+from ..orm import ORMConfig, ORMLifecycle
+
+LifecycleHook = Callable[[], Awaitable[None] | None]
+
+
+@runtime_checkable
+class RouterManager(Protocol):
+    """Protocol describing router aggregators capable of mounting routes."""
+
+    def mount(self, app: FastAPI, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover - structural
+        """Mount managed routers onto ``app``."""
+
+
+class ApplicationFactory:
+    """Create configured FastAPI applications backed by FreeAdmin."""
+
+    def __init__(
+        self,
+        *,
+        settings: Any | None = None,
+        orm_config: ORMConfig | None = None,
+        router_manager: RouterManager | None = None,
+        packages: Iterable[str] | None = None,
+        boot_manager: BootManager | None = None,
+    ) -> None:
+        """Persist configuration and supporting services for application builds."""
+
+        self._settings = settings
+        self._orm_config = orm_config or ORMConfig()
+        self._router_manager = router_manager
+        self._packages: list[str] = []
+        self._startup_hooks: list[LifecycleHook] = []
+        self._shutdown_hooks: list[LifecycleHook] = []
+        self._bound_apps: set[int] = set()
+        self._boot_provided = boot_manager is not None
+        self._orm_lifecycle: ORMLifecycle = self._orm_config.create_lifecycle()
+        self._boot = boot_manager or BootManager(
+            adapter_name=self._orm_lifecycle.adapter_name
+        )
+        self.register_packages(packages or ("apps", "pages"))
+
+    def register_packages(self, packages: Iterable[str]) -> None:
+        """Register discovery packages ensuring every entry is unique."""
+
+        for package in packages:
+            if not package:
+                continue
+            if package not in self._packages:
+                self._packages.append(package)
+
+    def register_startup_hook(self, hook: LifecycleHook) -> None:
+        """Store a coroutine or callable to execute during application startup."""
+
+        self._startup_hooks.append(hook)
+
+    def register_shutdown_hook(self, hook: LifecycleHook) -> None:
+        """Store a coroutine or callable to execute during application shutdown."""
+
+        self._shutdown_hooks.append(hook)
+
+    def build(
+        self,
+        *,
+        settings: Any | None = None,
+        orm_config: ORMConfig | None = None,
+        router_manager: RouterManager | None = None,
+        packages: Iterable[str] | None = None,
+    ) -> FastAPI:
+        """Return a FastAPI instance wired with FreeAdmin integration."""
+
+        if settings is not None:
+            self._settings = settings
+        if orm_config is not None and orm_config is not self._orm_config:
+            self._orm_config = orm_config
+            self._orm_lifecycle = self._orm_config.create_lifecycle()
+            self._bound_apps.clear()
+            if not self._boot_provided:
+                self._boot = BootManager(
+                    adapter_name=self._orm_lifecycle.adapter_name
+                )
+        if router_manager is not None:
+            self._router_manager = router_manager
+        if packages is not None:
+            self.register_packages(packages)
+
+        title = getattr(self._settings, "project_title", None)
+        if title:
+            app = FastAPI(title=title)
+        else:
+            app = FastAPI()
+
+        self._initialize_orm(app)
+        self._boot.init(
+            app,
+            adapter=self._orm_lifecycle.adapter_name,
+            packages=list(self._packages),
+        )
+        self._mount_routers(app)
+        self._register_lifecycle_hooks(app)
+        return app
+
+    def _initialize_orm(self, app: FastAPI) -> None:
+        """Attach the ORM lifecycle handlers to ``app`` once."""
+
+        app_id = id(app)
+        if app_id in self._bound_apps:
+            return
+        self._orm_lifecycle.bind(app)
+        self._bound_apps.add(app_id)
+
+    def _mount_routers(self, app: FastAPI) -> None:
+        """Delegate route mounting to the configured router manager if present."""
+
+        if self._router_manager is None:
+            return
+        mount = getattr(self._router_manager, "mount", None)
+        if mount is None:
+            return
+        try:
+            params = list(signature(mount).parameters.values())
+        except (TypeError, ValueError):  # pragma: no cover - fallback for C implementations
+            mount(app)
+            return
+        if not params:
+            mount()
+            return
+        if len(params) == 1 or (
+            len(params) > 1 and params[1].default is not Parameter.empty
+        ):
+            mount(app)
+            return
+        from ..hub import admin_site
+
+        mount(app, admin_site)
+
+    def _register_lifecycle_hooks(self, app: FastAPI) -> None:
+        """Attach registered startup and shutdown hooks to ``app``."""
+
+        for hook in self._startup_hooks:
+            app.add_event_handler("startup", hook)
+        for hook in self._shutdown_hooks:
+            app.add_event_handler("shutdown", hook)
+
+
+__all__ = ["ApplicationFactory", "RouterManager"]
+
+
+# The End

--- a/tests/test_application_factory.py
+++ b/tests/test_application_factory.py
@@ -1,0 +1,91 @@
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+
+from freeadmin.application import ApplicationFactory
+from freeadmin.hub import admin_site
+
+
+class DummyLifecycle:
+    def __init__(self) -> None:
+        self.bind_calls = 0
+        self.adapter_name = "dummy-adapter"
+
+    def bind(self, app: FastAPI) -> None:
+        self.bind_calls += 1
+        app.state.lifecycle_bound = True
+
+
+class DummyORMConfig:
+    def __init__(self, lifecycle: DummyLifecycle) -> None:
+        self._lifecycle = lifecycle
+
+    def create_lifecycle(self) -> DummyLifecycle:
+        return self._lifecycle
+
+
+class DummyBootManager:
+    def __init__(self) -> None:
+        self.calls: list[tuple[FastAPI, str | None, list[str] | None]] = []
+
+    def init(
+        self,
+        app: FastAPI,
+        *,
+        adapter: str | None = None,
+        packages: list[str] | None = None,
+    ) -> None:
+        self.calls.append((app, adapter, list(packages) if packages else None))
+
+
+class DummyRouterManager:
+    def __init__(self) -> None:
+        self.app: FastAPI | None = None
+        self.site = None
+
+    def mount(self, app: FastAPI, site) -> None:  # type: ignore[override]
+        self.app = app
+        self.site = site
+
+
+async def sample_startup() -> None:
+    pass
+
+
+async def sample_shutdown() -> None:
+    pass
+
+
+def test_application_factory_builds_configured_app() -> None:
+    lifecycle = DummyLifecycle()
+    orm_config = DummyORMConfig(lifecycle)
+    boot_manager = DummyBootManager()
+    router_manager = DummyRouterManager()
+    settings = SimpleNamespace(project_title="Test Admin")
+
+    factory = ApplicationFactory(
+        settings=settings,
+        orm_config=orm_config,  # type: ignore[arg-type]
+        router_manager=router_manager,
+        boot_manager=boot_manager,  # type: ignore[arg-type]
+    )
+    factory.register_packages(["custom.apps"])
+    factory.register_packages(["pages"])  # Duplicate should be ignored.
+    factory.register_startup_hook(sample_startup)
+    factory.register_shutdown_hook(sample_shutdown)
+
+    app = factory.build()
+
+    assert isinstance(app, FastAPI)
+    assert app.title == "Test Admin"
+    assert lifecycle.bind_calls == 1
+    assert getattr(app.state, "lifecycle_bound", False) is True
+    assert boot_manager.calls
+    call_app, adapter_name, packages = boot_manager.calls[0]
+    assert call_app is app
+    assert adapter_name == lifecycle.adapter_name
+    assert packages == ["apps", "pages", "custom.apps"]
+    assert router_manager.app is app
+    assert router_manager.site is admin_site
+    assert sample_startup in app.router.on_startup
+    assert sample_shutdown in app.router.on_shutdown


### PR DESCRIPTION
## Summary
- add an ApplicationFactory that encapsulates settings, ORM lifecycle binding, router mounting, and BootManager integration
- expose the factory through the application package and top-level package exports
- cover the factory with a focused unit test exercising package registration and lifecycle hooks

## Testing
- pytest tests/test_application_factory.py


------
https://chatgpt.com/codex/tasks/task_e_68ee4a1a40cc83309f957a63cd9991c5