### PR TITLE
Clarify migration warning for system config

### DIFF
--- a/freeadmin/core/settings/config.py
+++ b/freeadmin/core/settings/config.py
@@ -77,7 +77,9 @@ class SystemConfig:
             await self._seed_defaults()
         except DATABASE_OPERATION_ERRORS as exc:
             logger.warning(
-                "Skipping system configuration seed due to database error: %s", exc
+                "Skipping system configuration seed due to database error: %s. "
+                "Run your migrations before starting FreeAdmin.",
+                exc,
             )
 
     async def _seed_defaults(self) -> None:
@@ -138,7 +140,9 @@ class SystemConfig:
                 new_cache.setdefault(key, self._cast(value, value_type))
         except DATABASE_OPERATION_ERRORS as exc:
             logger.warning(
-                "Skipping system configuration reload due to database error: %s", exc
+                "Skipping system configuration reload due to database error: %s. "
+                "Run your migrations before starting FreeAdmin.",
+                exc,
             )
             return
 

--- a/tests/test_system_config_startup.py
+++ b/tests/test_system_config_startup.py
@@ -75,6 +75,7 @@ async def test_ensure_seed_handles_operational_error(monkeypatch, caplog) -> Non
     await config.ensure_seed()
 
     assert "Skipping system configuration seed" in caplog.text
+    assert "Run your migrations before starting FreeAdmin." in caplog.text
 
 
 @pytest.mark.asyncio
@@ -91,6 +92,7 @@ async def test_reload_handles_operational_error(monkeypatch, caplog) -> None:
     await config.reload()
 
     assert "Skipping system configuration reload" in caplog.text
+    assert "Run your migrations before starting FreeAdmin." in caplog.text
 
 
 # The End


### PR DESCRIPTION
## Summary
- clarify system configuration warnings to direct users to run migrations when database errors occur
- update startup resilience tests to assert the expanded warning guidance

## Testing
- pytest tests/test_system_config_startup.py

------
https://chatgpt.com/codex/tasks/task_e_68ee6f767cc48330afca569df233f43b