### PR TITLE
Add router aggregator support

### DIFF
--- a/freeadmin/router/__init__.py
+++ b/freeadmin/router/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+"""
+router
+
+Public exports for router utilities.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from .base import AdminRouter
+from .aggregator import RouterAggregator
+
+
+
+# The End
+

--- a/freeadmin/router/aggregator.py
+++ b/freeadmin/router/aggregator.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+"""
+router.aggregator
+
+Coordinator for creating, caching, and mounting admin routers.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+from weakref import WeakSet
+
+from fastapi import APIRouter, FastAPI
+
+from ..conf import FreeAdminSettings, current_settings
+from ..core.settings import SettingsKey, system_config
+from ..core.site import AdminSite
+from ..provider import TemplateProvider
+
+ASSETS_DIR = Path(__file__).resolve().parent.parent / "static"
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
+
+
+class RouterAggregator:
+    """Coordinate creation and mounting of admin routers."""
+
+    def __init__(
+        self,
+        site: AdminSite,
+        prefix: str | None = None,
+        *,
+        settings: FreeAdminSettings | None = None,
+    ) -> None:
+        """Initialise the aggregator with the admin site and base settings."""
+
+        self.site = site
+        self._settings = settings or current_settings()
+        default_prefix = system_config.get_cached(
+            SettingsKey.ADMIN_PREFIX, self._settings.admin_path
+        )
+        self._prefix = (prefix or default_prefix).rstrip("/")
+        self._provider = TemplateProvider(
+            templates_dir=str(TEMPLATES_DIR),
+            static_dir=str(ASSETS_DIR),
+            settings=self._settings,
+        )
+        self._admin_router: APIRouter | None = None
+        self._mounted_apps: WeakSet[FastAPI] = WeakSet()
+
+    @property
+    def prefix(self) -> str:
+        """Return the current prefix used for mounting the admin router."""
+
+        return self._prefix
+
+    def create_admin_router(self) -> APIRouter:
+        """Instantiate the FastAPI router for the admin site."""
+
+        return self.site.build_router(self._provider)
+
+    def get_admin_router(self) -> APIRouter:
+        """Return the cached admin router, creating it when necessary."""
+
+        if self._admin_router is None:
+            self._admin_router = self.create_admin_router()
+        return self._admin_router
+
+    def mount(self, app: FastAPI, prefix: str | None = None) -> None:
+        """Mount the admin router and any configured extras onto the app."""
+
+        self._prefix = (prefix or self._prefix).rstrip("/")
+        self._ensure_templates()
+        app.state.admin_site = self.site
+        if app in self._mounted_apps:
+            return
+
+        router = self.get_admin_router()
+        app.include_router(router, prefix=self._prefix)
+        self._provider.mount_static(app, self._prefix)
+        self._provider.mount_favicon(app)
+        self._provider.mount_media(app)
+        self.register_additional_routers(app)
+        self._mounted_apps.add(app)
+
+    def register_additional_routers(self, app: FastAPI) -> None:
+        """Register optional routers returned by :meth:`get_additional_routers`."""
+
+        for router, router_prefix in self.get_additional_routers():
+            app.include_router(router, prefix=router_prefix or "")
+
+    def get_additional_routers(self) -> Iterable[tuple[APIRouter, str | None]]:
+        """Return routers that should be mounted alongside the admin router."""
+
+        return ()
+
+    def _ensure_templates(self) -> None:
+        if self.site.templates is None:
+            self.site.templates = self._provider.get_templates()
+
+
+
+# The End
+
+

--- a/freeadmin/router/base.py
+++ b/freeadmin/router/base.py
@@ -11,15 +11,16 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 from pathlib import Path
+
 from fastapi import FastAPI
 
-from .conf import FreeAdminSettings, current_settings
-from .core.settings import SettingsKey, system_config
-from .core.site import AdminSite
-from .provider import TemplateProvider
+from ..conf import FreeAdminSettings, current_settings
+from ..core.settings import SettingsKey, system_config
+from ..core.site import AdminSite
+from ..provider import TemplateProvider
 
-ASSETS_DIR = Path(__file__).parent / "static"
-TEMPLATES_DIR = Path(__file__).parent / "templates"
+ASSETS_DIR = Path(__file__).resolve().parent.parent / "static"
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
 
 
 class AdminRouter:

--- a/freeadmin/tests/test_router_aggregator.py
+++ b/freeadmin/tests/test_router_aggregator.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""
+tests.test_router_aggregator
+
+Unit tests for the router aggregator utility.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from unittest.mock import MagicMock
+
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+
+from freeadmin.router import RouterAggregator
+
+
+def _build_site(router: APIRouter) -> MagicMock:
+    site = MagicMock()
+    site.templates = None
+    site.build_router.return_value = router
+    return site
+
+
+def test_mount_is_idempotent() -> None:
+    """Calling ``mount`` repeatedly must not duplicate admin resources."""
+
+    app = FastAPI()
+    admin_router = APIRouter()
+
+    @admin_router.get("/dashboard")
+    def dashboard() -> dict[str, str]:
+        return {"status": "ok"}
+
+    site = _build_site(admin_router)
+    aggregator = RouterAggregator(site=site, prefix="/admin")
+    aggregator._provider.mount_static = MagicMock()  # type: ignore[attr-defined]
+    aggregator._provider.mount_favicon = MagicMock()  # type: ignore[attr-defined]
+    aggregator._provider.mount_media = MagicMock()  # type: ignore[attr-defined]
+
+    aggregator.mount(app)
+    initial_route_count = len(app.router.routes)
+    aggregator.mount(app)
+    subsequent_route_count = len(app.router.routes)
+
+    assert site.build_router.call_count == 1
+    assert aggregator.get_admin_router() is admin_router
+    assert initial_route_count == subsequent_route_count
+    aggregator._provider.mount_static.assert_called_once_with(app, "/admin")  # type: ignore[attr-defined]
+    aggregator._provider.mount_favicon.assert_called_once_with(app)  # type: ignore[attr-defined]
+    aggregator._provider.mount_media.assert_called_once_with(app)  # type: ignore[attr-defined]
+    assert app.state.admin_site is site
+
+
+def test_subclass_can_register_extra_routers() -> None:
+    """Subclasses should be able to expose bespoke routers."""
+
+    app = FastAPI()
+    admin_router = APIRouter()
+
+    @admin_router.get("/home")
+    def home() -> dict[str, str]:
+        return {"status": "home"}
+
+    extra_router = APIRouter()
+
+    @extra_router.get("/extras/ping")
+    def ping() -> dict[str, str]:
+        return {"pong": "ok"}
+
+    site = _build_site(admin_router)
+
+    class CustomRouterAggregator(RouterAggregator):
+        """Router aggregator providing an extra router."""
+
+        def get_additional_routers(self) -> Iterable[tuple[APIRouter, str | None]]:  # type: ignore[override]
+            """Return the extra router configured for the test."""
+
+            return ((extra_router, ""),)
+
+    aggregator = CustomRouterAggregator(site=site, prefix="/admin")
+    aggregator._provider.mount_static = MagicMock()  # type: ignore[attr-defined]
+    aggregator._provider.mount_favicon = MagicMock()  # type: ignore[attr-defined]
+    aggregator._provider.mount_media = MagicMock()  # type: ignore[attr-defined]
+    aggregator.mount(app)
+
+    client = TestClient(app)
+    response = client.get("/extras/ping")
+    assert response.status_code == 200
+    assert response.json() == {"pong": "ok"}
+
+    aggregator.mount(app)
+    assert site.build_router.call_count == 1
+
+
+
+# The End
+


### PR DESCRIPTION
## Summary
- add a RouterAggregator utility to coordinate admin router creation, caching, and mounting hooks
- package the router module to re-export AdminRouter and RouterAggregator
- add tests covering idempotent mounting and subclass router registration

## Testing
- pytest freeadmin/tests/test_router_aggregator.py

------
https://chatgpt.com/codex/tasks/task_e_68ee79614c9483308e165c251eaf63f1