### PR TITLE
Refine router CLI template to use RouterAggregator

### DIFF
--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -43,8 +43,9 @@ class TestProjectInitializerConfigTemplates:
         assert "ORM_CONFIG" in orm_content
         assert "ORM: ORMConfig = ORMConfig.build" in orm_content
         assert ROUTER_TEMPLATE_CLASS_NAME in routers_content
-        assert "def get_admin_router" in routers_content
-        assert "_ROUTER_AGGREGATOR" in routers_content
+        assert "RouterAggregator" in routers_content
+        assert "super().mount" in routers_content
+        assert "return ((reports_router, \"/reports\"),)" in routers_content
         assert "ProjectSettings" in settings_content
         assert "project_title" in settings_content
 


### PR DESCRIPTION
## Summary
- update the generated routers.py template to subclass RouterAggregator and export a configured instance
- add guidance comments about declaring project-specific routers while delegating mounting to the base class
- extend the CLI scaffold test to assert the new template content

## Testing
- pytest tests/test_cli_init.py

------
https://chatgpt.com/codex/tasks/task_e_68ee82cfc9c48330a3895bbecd61a76b