### PR TITLE
Add declarative router registration helpers

### DIFF
--- a/docs/installation-and-cli.md
+++ b/docs/installation-and-cli.md
@@ -267,8 +267,6 @@ The default discovery packages (`apps` and `pages`) match the directories create
 
 ```python
 # config/routers.py
-from collections.abc import Iterable
-
 from fastapi import APIRouter
 
 from freeadmin.hub import admin_site
@@ -282,18 +280,16 @@ class ProjectRouterAggregator(RouterAggregator):
         """Initialise the aggregator with the admin site."""
 
         super().__init__(site=admin_site)
-
-    def get_additional_routers(self) -> Iterable[tuple[APIRouter, str | None]]:
-        """Return project-specific routers to mount with the admin UI."""
-
-        return ()
+        # Declare additional routers when your project exposes them:
+        # reports_router = APIRouter()
+        # self.add_additional_router(reports_router, "/reports")
 
 
 ROUTERS = ProjectRouterAggregator()
 
 ```
 
-Override `get_additional_routers()` to yield `(router, prefix)` tuples whenever you need to expose extra APIs. The `RouterAggregator` base class ensures the admin router, static assets, and favicon are mounted once per application instance and provides helpers such as `register_additional_routers()` if you need to trigger mounting manually.
+Call `add_additional_router()` (or pass `additional_routers` to `RouterAggregator.__init__()`) whenever you need to expose extra APIs. The `RouterAggregator` base class ensures the admin router, static assets, and favicon are mounted once per application instance and provides helpers such as `register_additional_routers()` if you need to trigger mounting manually.
 
 
 ## Step 9. Configure the database URL

--- a/example/config/routers.py
+++ b/example/config/routers.py
@@ -11,8 +11,6 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-
 from fastapi import APIRouter
 from fastapi.responses import PlainTextResponse, RedirectResponse
 
@@ -29,27 +27,8 @@ class ExampleRouterAggregator(RouterAggregator):
         """Initialise the example router aggregator with default routes."""
 
         super().__init__(admin_site)
-        self._card_router = card_public_router
-        self._public_router = self._create_public_router()
-
-    @property
-    def card_router(self) -> APIRouter:
-        """Return the router exposing card endpoints to the public."""
-
-        return self._card_router
-
-    @property
-    def public_router(self) -> APIRouter:
-        """Return the router exposing public redirect endpoints."""
-
-        return self._public_router
-
-    def get_additional_routers(self) -> Iterable[tuple[APIRouter, str | None]]:
-        """Return card and public routers to mount alongside the admin site."""
-
-        yield from super().get_additional_routers()
-        yield self.card_router, None
-        yield self.public_router, None
+        self.add_additional_router(card_public_router, None)
+        self.add_additional_router(self._create_public_router(), None)
 
     def _create_public_router(self) -> APIRouter:
         router = APIRouter()

--- a/freeadmin/utils/cli/project_initializer.py
+++ b/freeadmin/utils/cli/project_initializer.py
@@ -240,8 +240,6 @@ Routing helpers for {project_name}.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-
 from fastapi import APIRouter, FastAPI
 
 from freeadmin.core.site import AdminSite
@@ -257,10 +255,18 @@ class {router_class}(RouterAggregator):
         site: AdminSite,
         *,
         prefix: str | None = None,
+        additional_routers: tuple[tuple[APIRouter, str | None], ...] | None = None,
     ) -> None:
         """Initialise the aggregator with the admin site and prefix."""
 
-        super().__init__(site=site, prefix=prefix)
+        super().__init__(
+            site=site,
+            prefix=prefix,
+            additional_routers=additional_routers,
+        )
+        # Declare routers here when you do not want to pass them in as
+        # ``additional_routers``.
+        # self.add_additional_router(reports_router, "/reports")
 
     def mount(self, app: FastAPI, prefix: str | None = None) -> None:  # type: ignore[override]
         """Mount the admin UI and project routers onto ``app``."""
@@ -268,13 +274,6 @@ class {router_class}(RouterAggregator):
         super().mount(app, prefix=prefix)
         # Delegate admin mounting to ``RouterAggregator`` and extend this
         # method only when additional side effects are required.
-
-    def get_additional_routers(self) -> Iterable[tuple[APIRouter, str | None]]:  # type: ignore[override]
-        """Return project-specific routers to include with the admin UI."""
-
-        # Declare routers here, for example:
-        # return ((reports_router, "/reports"),)
-        return ()
 
 
 ROUTERS: {router_class} = {router_class}(site=admin_site)

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -45,7 +45,7 @@ class TestProjectInitializerConfigTemplates:
         assert ROUTER_TEMPLATE_CLASS_NAME in routers_content
         assert "RouterAggregator" in routers_content
         assert "super().mount" in routers_content
-        assert "return ((reports_router, \"/reports\"),)" in routers_content
+        assert "self.add_additional_router(reports_router, \"/reports\")" in routers_content
         assert "ProjectSettings" in settings_content
         assert "project_title" in settings_content
 


### PR DESCRIPTION
## Summary
- extend RouterAggregator with constructor support for pre-declared routers and an add_additional_router helper
- update the example configuration, CLI template, documentation, and tests to use the helper-based registration pattern

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee897e8a388330929cbc361babc912