### PR TITLE
Make example public router helper public

### DIFF
--- a/example/config/routers.py
+++ b/example/config/routers.py
@@ -28,9 +28,11 @@ class ExampleRouterAggregator(RouterAggregator):
 
         super().__init__(admin_site)
         self.add_additional_router(card_public_router, None)
-        self.add_additional_router(self._create_public_router(), None)
+        self.add_additional_router(self.create_public_router(), None)
 
-    def _create_public_router(self) -> APIRouter:
+    def create_public_router(self) -> APIRouter:
+        """Build the public router exposed by the example project."""
+
         router = APIRouter()
         login_path = system_config.get_cached(SettingsKey.LOGIN_PATH, "/login")
         logout_path = system_config.get_cached(SettingsKey.LOGOUT_PATH, "/logout")


### PR DESCRIPTION
## Summary
- rename the example public router factory to `create_public_router`
- expose the helper through the aggregator initialisation call
- document the helper with an inline docstring to highlight its public status

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee8aec08bc83308cc71fd539c564cc