### PR TITLE
Update scaffold settings to use pydantic-settings

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,11 +56,11 @@ Every admin component registered after this call receives the customised setting
 
 ## Integrating with project settings
 
-The scaffolded `config/settings.py` uses `pydantic.BaseSettings` so you can maintain project-specific configuration independently of FreeAdmin. For example:
+The scaffolded `config/settings.py` uses `pydantic_settings.BaseSettings` so you can maintain project-specific configuration independently of FreeAdmin. For example:
 
 ```python
 # config/settings.py
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 
 class ProjectSettings(BaseSettings):

--- a/docs/installation-and-cli.md
+++ b/docs/installation-and-cli.md
@@ -77,11 +77,11 @@ The generated files are intentionally minimal so you can adapt them to your stac
 
 ## Step 4. Configure project settings
 
-Edit `config/settings.py` to describe your environment. The scaffold uses `pydantic.BaseSettings`, so environment variables automatically override defaults:
+Edit `config/settings.py` to describe your environment. The scaffold uses `pydantic_settings.BaseSettings`, so environment variables automatically override defaults:
 
 ```python
 # config/settings.py
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 
 class ProjectSettings(BaseSettings):

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -33,7 +33,7 @@ The `config` package defines how the admin integrates with your FastAPI applicat
 | ---- | ------- |
 | `main.py` | Creates the FastAPI app and should call `BootManager.init()` to mount FreeAdmin. |
 | `orm.py` | Declares adapter constants and exports an `ORMConfig` instance with lifecycle helpers. |
-| `settings.py` | Declares the `ProjectSettings` model backed by `pydantic.BaseSettings`. |
+| `settings.py` | Declares the `ProjectSettings` model backed by `pydantic_settings.BaseSettings`. |
 
 After customisation a typical `main.py` instantiates the generated `ApplicationFactory`, which in turn coordinates `BootManager` and the ORM lifecycle:
 

--- a/freeadmin/utils/cli/project_initializer.py
+++ b/freeadmin/utils/cli/project_initializer.py
@@ -212,7 +212,7 @@ Primary configuration object for {project_name}.
 
 from __future__ import annotations
 
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 
 class ProjectSettings(BaseSettings):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "tortoise-orm>=0.20,<0.22",
     "python-multipart>=0.0.7,<0.0.9",
     "pydantic>=1.10,<3.0",
+    "pydantic-settings>=2.0,<3.0",
     "pyjwt>=2.8,<3.0",
     "openpyxl>=3.1,<4.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ itsdangerous>=2.1,<3.0
 tortoise-orm>=0.20,<0.22
 python-multipart>=0.0.7,<0.0.9
 pydantic>=1.10,<3.0
+pydantic-settings>=2.0,<3.0
 pyjwt>=2.8,<3.0
 openpyxl>=3.1,<4.0
 lxml>=4.9,<6.0


### PR DESCRIPTION
## Summary
- update the project settings template to import BaseSettings from pydantic-settings
- refresh documentation to reference pydantic-settings for configuration examples
- add pydantic-settings to the package dependencies so generated projects install it automatically

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ef63c00dc88330a6bfa45db30943e0