### PR TITLE
docs: clarify bootstrap guide imports for BaseSettings

### DIFF
--- a/docs/admin/APPLICATION_BOOTSTRAP.md
+++ b/docs/admin/APPLICATION_BOOTSTRAP.md
@@ -5,10 +5,14 @@ This guide walks you through the process of enabling a new FreeAdmin application
 ## 1. Register the application in settings
 
 1. Open `config/settings.py`.
-2. Locate the `Settings` dataclass and append the dotted path of your application package (without the trailing `.app`) to `Settings.INSTALLED_APPS`.
-3. Save the file so the importable settings reflect the new entries.
+2. Ensure the module imports `BaseSettings` from `pydantic_settings` so it remains compatible with Pydantic v2.
+3. Locate the `Settings` dataclass and append the dotted path of your application package (without the trailing `.app`) to `Settings.INSTALLED_APPS`.
+4. Save the file so the importable settings reflect the new entries.
 
 ```python
+from pydantic_settings import BaseSettings
+
+
 class Settings(BaseSettings):
     INSTALLED_APPS: ClassVar[list[str]] = [
         "core.agents",


### PR DESCRIPTION
## Summary
- remind readers to import BaseSettings from the pydantic-settings package in the bootstrap guide
- note the pydantic v2 requirement directly in the step list before editing INSTALLED_APPS

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ef6779bdf48330a4288a39ea344814