### PR TITLE
Generalize migration error handling for admin startup

### DIFF
--- a/freeadmin/utils/migration_errors.py
+++ b/freeadmin/utils/migration_errors.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""
+migration_errors
+
+Helpers for classifying database exceptions that stem from missing migrations.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Iterator, Tuple
+
+
+class MigrationErrorClassifier:
+    """Classify database errors that originate from missing schema objects."""
+
+    _default_tokens: Tuple[str, ...] = (
+        "no such table",
+        "does not exist",
+        "missing table",
+        "missing relation",
+        "undefined table",
+        "unknown table",
+    )
+
+    def __init__(self, *, tokens: Iterable[str] | None = None) -> None:
+        """Store the lowercase token set used to match database errors."""
+
+        selected = tokens if tokens is not None else self._default_tokens
+        self._tokens: Tuple[str, ...] = tuple(token.lower() for token in selected)
+
+    def is_missing_schema(self, error: BaseException | None) -> bool:
+        """Return ``True`` when ``error`` signals absent migration artefacts."""
+
+        if error is None:
+            return False
+        for candidate in self._iterate_error_chain(error):
+            message = str(candidate).lower()
+            if any(token in message for token in self._tokens):
+                return True
+        return False
+
+    def _iterate_error_chain(self, error: BaseException) -> Iterator[BaseException]:
+        seen: set[int] = set()
+        stack: list[BaseException] = [error]
+        while stack:
+            current = stack.pop()
+            identifier = id(current)
+            if identifier in seen:
+                continue
+            seen.add(identifier)
+            yield current
+            cause = getattr(current, "__cause__", None)
+            if isinstance(cause, BaseException):
+                stack.append(cause)
+            context = getattr(current, "__context__", None)
+            if isinstance(context, BaseException):
+                stack.append(context)
+
+
+# The End

--- a/tests/test_admin_site_finalize.py
+++ b/tests/test_admin_site_finalize.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""Tests ensuring AdminSite.finalize tolerates missing migrations."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from tortoise import Tortoise
+
+from freeadmin.boot import admin as boot_admin
+from freeadmin.core import site as site_module
+from freeadmin.core.site import AdminSite
+from tests.system_models import system_models
+
+
+@pytest.mark.asyncio
+async def test_finalize_logs_hint_when_admin_tables_missing(caplog) -> None:
+    """AdminSite.finalize should log a migration hint when tables are absent."""
+
+    await Tortoise._reset_apps()
+    await Tortoise.init(
+        db_url="sqlite://:memory:",
+        modules={
+            "models": [],
+            "admin": list(system_models.module_names()),
+        },
+    )
+
+    site = AdminSite(boot_admin.adapter, title="Test")
+
+    caplog.set_level(logging.ERROR, logger=site_module.logger.name)
+
+    try:
+        await site.finalize()
+    finally:
+        await Tortoise.close_connections()
+        await Tortoise._reset_apps()
+
+    assert "Skipping admin content type synchronisation" in caplog.text
+    assert "Run your migrations before starting FreeAdmin." in caplog.text
+
+
+# The End

--- a/tests/test_orm_lifecycle_startup.py
+++ b/tests/test_orm_lifecycle_startup.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""Tests ensuring ORM lifecycle tolerates missing migrations on startup."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from tortoise.exceptions import OperationalError
+
+from freeadmin.orm import ORMConfig, ORMLifecycle
+from freeadmin.orm import config as orm_config_module
+
+
+@pytest.mark.asyncio
+async def test_startup_logs_hint_when_migrations_missing(monkeypatch, caplog) -> None:
+    """The lifecycle should log a helpful error message instead of failing."""
+
+    config = ORMConfig(dsn="sqlite://:memory:", modules={"models": []})
+    lifecycle = ORMLifecycle(config=config)
+
+    error = OperationalError("missing table admin_content_type")
+
+    async def failing_init(*args, **kwargs):
+        raise error
+
+    monkeypatch.setattr(orm_config_module.Tortoise, "init", failing_init)
+
+    caplog.set_level(
+        logging.ERROR,
+        logger=orm_config_module.ORMLifecycle._logger.name,
+    )
+
+    await lifecycle.startup()
+
+    assert "Failed to initialise ORM" in caplog.text
+    assert "Run your migrations before starting FreeAdmin." in caplog.text
+    assert str(error) in caplog.text
+
+
+# The End
+


### PR DESCRIPTION
## Summary
- introduce a reusable migration error classifier to identify missing schema failures without database-specific imports
- use the classifier during admin content type synchronisation so startup logs guidance yet re-raises unrelated errors
- reuse the classifier in the ORM lifecycle to surface migration hints consistently across adapters

## Testing
- pytest tests/test_admin_site_finalize.py tests/test_orm_lifecycle_startup.py tests/test_system_config_startup.py

------
https://chatgpt.com/codex/tasks/task_e_68ef7351b6f88330b8e4c80a980b56dc