### PR TITLE
Refine migration error classification safeguards

### DIFF
--- a/freeadmin/utils/migration_errors.py
+++ b/freeadmin/utils/migration_errors.py
@@ -17,20 +17,34 @@ from typing import Iterable, Iterator, Tuple
 class MigrationErrorClassifier:
     """Classify database errors that originate from missing schema objects."""
 
-    _default_tokens: Tuple[str, ...] = (
-        "no such table",
-        "does not exist",
-        "missing table",
-        "missing relation",
-        "undefined table",
-        "unknown table",
+    _default_tokens: Tuple[Tuple[str, ...], ...] = (
+        ("no such table",),
+        ("missing table",),
+        ("missing relation",),
+        ("undefined table",),
+        ("unknown table",),
+        ("relation", "does not exist"),
+        ("table", "does not exist"),
+        ("column", "does not exist"),
+        ("index", "does not exist"),
     )
 
-    def __init__(self, *, tokens: Iterable[str] | None = None) -> None:
-        """Store the lowercase token set used to match database errors."""
+    _missing_schema_error_names: Tuple[str, ...] = (
+        "NoSuchTableError",
+        "NoSuchColumnError",
+        "UndefinedTable",
+        "UndefinedColumn",
+    )
+
+    def __init__(
+        self,
+        *,
+        tokens: Iterable[str] | Iterable[Iterable[str]] | None = None,
+    ) -> None:
+        """Store the lowercase token combinations used to match database errors."""
 
         selected = tokens if tokens is not None else self._default_tokens
-        self._tokens: Tuple[str, ...] = tuple(token.lower() for token in selected)
+        self._tokens: Tuple[Tuple[str, ...], ...] = self._normalize_tokens(selected)
 
     def is_missing_schema(self, error: BaseException | None) -> bool:
         """Return ``True`` when ``error`` signals absent migration artefacts."""
@@ -38,12 +52,38 @@ class MigrationErrorClassifier:
         if error is None:
             return False
         for candidate in self._iterate_error_chain(error):
+            if self._matches_known_error_type(candidate):
+                return True
             message = str(candidate).lower()
-            if any(token in message for token in self._tokens):
+            if any(
+                all(part in message for part in combination)
+                for combination in self._tokens
+            ):
                 return True
         return False
 
+    def _matches_known_error_type(self, error: BaseException) -> bool:
+        """Return ``True`` when ``error`` has a class name associated with schema misses."""
+
+        name = type(error).__name__
+        return name in self._missing_schema_error_names
+
+    def _normalize_tokens(
+        self, selected: Iterable[str] | Iterable[Iterable[str]]
+    ) -> Tuple[Tuple[str, ...], ...]:
+        """Convert ``selected`` token definitions into normalized lowercase tuples."""
+
+        normalized: list[Tuple[str, ...]] = []
+        for combination in selected:
+            if isinstance(combination, str):
+                normalized.append((combination.lower(),))
+            else:
+                normalized.append(tuple(part.lower() for part in combination))
+        return tuple(normalized)
+
     def _iterate_error_chain(self, error: BaseException) -> Iterator[BaseException]:
+        """Yield every exception linked to ``error`` via ``__cause__``/``__context__``."""
+
         seen: set[int] = set()
         stack: list[BaseException] = [error]
         while stack:


### PR DESCRIPTION
## Summary
- narrow default migration error tokens so generic configuration errors no longer match
- detect well-known missing schema exception types before consulting token-based heuristics
- normalize custom token input to support both legacy single-token and multi-token definitions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ef7a0af56c833093e55d41e0695757