### PR TITLE
Mount public welcome router in example aggregator

### DIFF
--- a/example/config/routers.py
+++ b/example/config/routers.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from fastapi import APIRouter
 from fastapi.responses import PlainTextResponse, RedirectResponse
 
+from example.pages import public_welcome_router
 from freeadmin.api.cards import public_router as card_public_router
 from freeadmin.core.settings import SettingsKey, system_config
 from freeadmin.hub import admin_site
@@ -28,6 +29,7 @@ class ExampleRouterAggregator(RouterAggregator):
 
         super().__init__(admin_site)
         self.add_additional_router(card_public_router, None)
+        self.add_additional_router(public_welcome_router, None)
         self.add_additional_router(self.create_public_router(), None)
 
     def create_public_router(self) -> APIRouter:

--- a/tests/test_example_application.py
+++ b/tests/test_example_application.py
@@ -42,6 +42,19 @@ class TestExampleApplicationSmoke:
 
         assert getattr(app.state, "admin_site", None) is not None
 
+    def test_public_welcome_route_mounted(self) -> None:
+        """Ensure building the example application exposes the welcome page."""
+
+        application = ExampleApplication()
+        app = application.build()
+
+        has_public_welcome_route = any(
+            route.path == "/" and "GET" in getattr(route, "methods", set())
+            for route in app.router.routes
+        )
+
+        assert has_public_welcome_route is True
+
 
 class TestExampleApplicationStartup:
     """Ensure application configs execute startup hooks during boot."""


### PR DESCRIPTION
## Summary
- register the example public welcome router with the default router aggregator
- ensure the example application mounts the welcome page without extra configuration

## Testing
- pytest tests/test_example_application.py::TestExampleApplicationSmoke::test_public_welcome_route_mounted -q

------
https://chatgpt.com/codex/tasks/task_e_68efd81bcde08330b60355a606eeb7a7