### PR TITLE
Move example template renderer into dedicated module

### DIFF
--- a/example/pages/welcome_page.py
+++ b/example/pages/welcome_page.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 
-from example.templates import ExampleTemplateRenderer
+from example.rendering import ExampleTemplateRenderer
 
 router = APIRouter()
 

--- a/example/rendering.py
+++ b/example/rendering.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-example.templates.renderer
+example.rendering
 
 Example utilities demonstrating how to render FreeAdmin templates for public pages.
 
@@ -20,7 +20,7 @@ from fastapi.templating import Jinja2Templates
 
 from freeadmin.conf import FreeAdminSettings, current_settings
 
-EXAMPLE_TEMPLATES_DIR = Path(__file__).resolve().parent
+EXAMPLE_TEMPLATES_DIR = Path(__file__).resolve().parent / "templates"
 ADMIN_TEMPLATES_DIR = EXAMPLE_TEMPLATES_DIR.parents[1] / "freeadmin" / "templates"
 
 
@@ -66,4 +66,3 @@ class ExampleTemplateRenderer:
 
 
 # The End
-

--- a/example/templates/__init__.py
+++ b/example/templates/__init__.py
@@ -11,9 +11,5 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 
-from .renderer import ExampleTemplateRenderer
-
-__all__ = ["ExampleTemplateRenderer"]
-
 # The End
 


### PR DESCRIPTION
## Summary
- move `ExampleTemplateRenderer` into a dedicated `example/rendering.py` module
- update imports to reference the new module
- trim `example/templates` so it only exposes template assets

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68efd830b49c8330acbe4f7f27968040