### PR TITLE
Document example page routers and handlers

### DIFF
--- a/docs/first-run-example.md
+++ b/docs/first-run-example.md
@@ -159,10 +159,11 @@ this keeps experiments reproducible.
 ### Standalone welcome page
 
 `example/pages/home.py` shows how to register additional views that are not tied
-to a specific application. The `ExampleWelcomePage` registers a friendly welcome
-screen under `/example/welcome` with custom iconography. The implementation uses
-`admin_site.build_template_ctx()` to reuse FreeAdmin’s standard layout while
-injecting its own message.
+to a specific application. The `ExampleWelcomePage` class keeps its registration
+logic encapsulated so the admin welcome screen mounts itself under
+`/example/welcome` exactly once and exposes the resulting handler for reuse.
+The implementation relies on `admin_site.build_template_ctx()` to reuse
+FreeAdmin’s standard layout while injecting its own message.
 
 ## Next steps
 

--- a/example/pages/__init__.py
+++ b/example/pages/__init__.py
@@ -12,11 +12,17 @@ Email: timurkady@yandex.com
 from __future__ import annotations
 
 from .home import ExampleWelcomePage, example_welcome_page
-from .welcome_page import router as public_welcome_router
+from .welcome_page import (
+    ExamplePublicWelcomePage,
+    example_public_welcome_page,
+    public_welcome_router,
+)
 
 __all__ = [
     "ExampleWelcomePage",
     "example_welcome_page",
+    "ExamplePublicWelcomePage",
+    "example_public_welcome_page",
     "public_welcome_router",
 ]
 

--- a/example/pages/home.py
+++ b/example/pages/home.py
@@ -21,9 +21,13 @@ class ExampleWelcomePage:
         """Store helpers required for page registration."""
 
         self._site = admin_site
+        self._handler: (object | None) = None
 
     def register(self) -> None:
         """Attach the welcome page handler to the admin site."""
+
+        if self._handler is not None:
+            return
 
         @self._site.register_view(
             path=self.path,
@@ -42,6 +46,11 @@ class ExampleWelcomePage:
             )
 
         self._handler = welcome_page
+
+    def get_handler(self) -> object | None:
+        """Return the registered handler for the admin welcome page."""
+
+        return self._handler
 
 
 example_welcome_page = ExampleWelcomePage()

--- a/example/pages/welcome_page.py
+++ b/example/pages/welcome_page.py
@@ -16,17 +16,49 @@ from fastapi.responses import HTMLResponse
 
 from example.rendering import ExampleTemplateRenderer
 
-router = APIRouter()
+
+class ExamplePublicWelcomePage:
+    """Expose a public welcome page mounted at the site root."""
+
+    path = "/"
+
+    def __init__(self) -> None:
+        """Initialise and register the public welcome page router."""
+
+        self._router = APIRouter()
+        self._handler: object | None = None
+        self._register_routes()
+
+    def get_router(self) -> APIRouter:
+        """Return the router that serves the public welcome page."""
+
+        return self._router
+
+    def get_handler(self) -> object | None:
+        """Return the registered handler for the public welcome page."""
+
+        return self._handler
+
+    def _register_routes(self) -> None:
+        """Register HTTP routes for the public welcome page."""
+
+        @self._router.get(self.path, response_class=HTMLResponse)
+        async def index(request: Request) -> HTMLResponse:
+            return self._render_response(request)
+
+        self._handler = index
+
+    def _render_response(self, request: Request) -> HTMLResponse:
+        """Render the welcome template for anonymous visitors."""
+
+        context = {"title": "Welcome", "user": None}
+        return ExampleTemplateRenderer.render(
+            "welcome.html", context, request=request
+        )
 
 
-@router.get("/", response_class=HTMLResponse)
-async def index(request: Request) -> HTMLResponse:
-    """Render the welcome page example for anonymous visitors."""
-
-    context = {"title": "Welcome", "user": None}
-    return ExampleTemplateRenderer.render(
-        "welcome.html", context, request=request
-    )
+example_public_welcome_page = ExamplePublicWelcomePage()
+public_welcome_router = example_public_welcome_page.get_router()
 
 
 # The End


### PR DESCRIPTION
## Summary
- document the class-based public welcome page example and export usage updates
- note the admin welcome page encapsulation behaviour in the first-run guide
- expose the public welcome handler for reuse while keeping router registration intact

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68efda3874908330809ebdf006a9c889