### PR TITLE
Refactor admin router integration

### DIFF
--- a/docs/admin/frontend.md
+++ b/docs/admin/frontend.md
@@ -52,8 +52,8 @@ dependency during development.
 ## Favicon
 
 Save the `favicon.ico` file in `contrib/admin/static/`. `TemplateProvider.mount_favicon`
-mounts this file at `/favicon.ico` during `AdminRouter` initialization so that
-it is automatically available to browsers.
+mounts this file at `/favicon.ico` when the router aggregator attaches the
+admin interface, ensuring it is automatically available to browsers.
 
 <!-- # The End -->
 

--- a/docs/admin/hub-router.md
+++ b/docs/admin/hub-router.md
@@ -28,7 +28,7 @@ The call above imports all admin modules from the listed packages and mounts the
 
 ## Mounting and assets
 
-`AdminRouter.mount` performs the integration with FastAPI. It attaches the admin router, stores the site on `app.state`, and delegates template and static handling to `TemplateProvider`.
+`AdminRouter.mount` delegates to the underlying `RouterAggregator`. The aggregator attaches the admin router, stores the site on `app.state`, and delegates template and static handling to `TemplateProvider` while caching those mounts so repeated calls stay idempotent.
 
 `TemplateProvider` builds the `Jinja2Templates` environment and mounts static files under the admin's prefix so that templates and assets are available without additional configuration.
 

--- a/docs/core-concepts-and-terminology.md
+++ b/docs/core-concepts-and-terminology.md
@@ -88,7 +88,7 @@ This snippet initialises the adapter, discovers admin registrations inside `my_p
 
 ## AdminRouter
 
-`AdminRouter` mounts the admin application onto FastAPI. You rarely instantiate it manually because `BootManager.init()` performs the work, but the class is available if you need full control over the mounting process or want to embed the admin site inside another ASGI application.
+`AdminRouter` mounts the admin application onto FastAPI. You rarely instantiate it manually because `BootManager.init()` performs the work, but the class is available if you need full control over the mounting process or want to embed the admin site inside another ASGI application. The router is a lightweight wrapper around `RouterAggregator`, exposing the cached aggregator via `.aggregator` for advanced scenarios where you need to add extra routers or inspect the mounted state.
 
 
 ## Cards

--- a/freeadmin/application/factory.py
+++ b/freeadmin/application/factory.py
@@ -132,7 +132,10 @@ class ApplicationFactory:
         """Delegate route mounting to the configured router manager if present."""
 
         if self._router_manager is None:
-            return
+            from ..hub import admin_site
+            from ..router import AdminRouter
+
+            self._router_manager = AdminRouter(admin_site)
         mount = getattr(self._router_manager, "mount", None)
         if mount is None:
             return

--- a/freeadmin/router/aggregator.py
+++ b/freeadmin/router/aggregator.py
@@ -12,21 +12,17 @@ Email: timurkady@yandex.com
 from __future__ import annotations
 
 from collections.abc import Iterable
-from pathlib import Path
 from weakref import WeakSet
 
-from fastapi import APIRouter, FastAPI, Request
+from fastapi import APIRouter, FastAPI
 
-from ..conf import FreeAdminSettings, current_settings
+from ..conf import FreeAdminSettings
 from ..core.settings import SettingsKey, system_config
 from ..core.site import AdminSite
-from ..provider import TemplateProvider
-
-ASSETS_DIR = Path(__file__).resolve().parent.parent / "static"
-TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
+from .base import RouterFoundation
 
 
-class RouterAggregator:
+class RouterAggregator(RouterFoundation):
     """Coordinate creation and mounting of admin routers."""
 
     def __init__(
@@ -39,17 +35,12 @@ class RouterAggregator:
     ) -> None:
         """Initialise the aggregator with the admin site and base settings."""
 
+        super().__init__(settings=settings)
         self.site = site
-        self._settings = settings or current_settings()
         default_prefix = system_config.get_cached(
             SettingsKey.ADMIN_PREFIX, self._settings.admin_path
         )
         self._prefix = (prefix or default_prefix).rstrip("/")
-        self._provider = TemplateProvider(
-            templates_dir=str(TEMPLATES_DIR),
-            static_dir=str(ASSETS_DIR),
-            settings=self._settings,
-        )
         self._admin_router: APIRouter | None = None
         self._mounted_apps: WeakSet[FastAPI] = WeakSet()
         self._additional_routers: list[tuple[APIRouter, str | None]] = list(
@@ -78,16 +69,14 @@ class RouterAggregator:
         """Mount the admin router and any configured extras onto the app."""
 
         self._prefix = (prefix or self._prefix).rstrip("/")
-        self._ensure_templates()
+        self.ensure_site_templates(self.site)
         app.state.admin_site = self.site
         if app in self._mounted_apps:
             return
 
         router = self.get_admin_router()
         app.include_router(router, prefix=self._prefix)
-        self._provider.mount_static(app, self._prefix)
-        self._provider.mount_favicon(app)
-        self._provider.mount_media(app)
+        self.mount_static_resources(app, self._prefix)
         self.register_additional_routers(app)
         self._mounted_apps.add(app)
 
@@ -113,12 +102,6 @@ class RouterAggregator:
         yield from self._additional_routers
         if self.__class__.get_additional_routers is not RouterAggregator.get_additional_routers:  # type: ignore[misc]
             yield from self.get_additional_routers()
-
-    def _ensure_templates(self) -> None:
-        if self.site.templates is None:
-            self.site.templates = self._provider.get_templates()
-
-
 
 class ExtendedRouterAggregator(RouterAggregator):
     """Compose admin and public routers within a single aggregator."""
@@ -173,7 +156,7 @@ class ExtendedRouterAggregator(RouterAggregator):
     def get_routers(self) -> list[tuple[APIRouter, str | None]]:
         """Return all registered routers respecting the configured order."""
 
-        self._ensure_templates()
+        self.ensure_site_templates(self.site)
         admin_entries = self._collect_admin_entries()
         public_entries = [(router, None) for router in self._public_routers]
         if self._public_first:
@@ -184,16 +167,14 @@ class ExtendedRouterAggregator(RouterAggregator):
         """Mount public and admin routers onto ``app`` respecting order."""
 
         self._prefix = (prefix or self._prefix).rstrip("/")
-        self._ensure_templates()
+        self.ensure_site_templates(self.site)
         app.state.admin_site = self.site
         if app in self._mounted_apps:
             return
 
         for router, router_prefix in self.get_routers():
             app.include_router(router, prefix=router_prefix or "")
-        self._provider.mount_static(app, self._prefix)
-        self._provider.mount_favicon(app)
-        self._provider.mount_media(app)
+        self.mount_static_resources(app, self._prefix)
         self._mounted_apps.add(app)
 
     @property

--- a/freeadmin/router/aggregator.py
+++ b/freeadmin/router/aggregator.py
@@ -65,6 +65,11 @@ class RouterAggregator(RouterFoundation):
             self._admin_router = self.create_admin_router()
         return self._admin_router
 
+    def invalidate_admin_router(self) -> None:
+        """Drop the cached admin router so it rebuilds on next access."""
+
+        self._admin_router = None
+
     def mount(self, app: FastAPI, prefix: str | None = None) -> None:
         """Mount the admin router and any configured extras onto the app."""
 
@@ -187,6 +192,12 @@ class ExtendedRouterAggregator(RouterAggregator):
                 aggregated.include_router(router, prefix=router_prefix or "")
             self._router = aggregated
         return self._router
+
+    def invalidate_admin_router(self) -> None:
+        """Drop cached admin and aggregate routers to rebuild mappings."""
+
+        super().invalidate_admin_router()
+        self._invalidate_router_cache()
 
     def _collect_admin_entries(self) -> list[tuple[APIRouter, str | None]]:
         entries: list[tuple[APIRouter, str | None]] = [

--- a/tests/test_admin_hub_router_cache.py
+++ b/tests/test_admin_hub_router_cache.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""Tests covering AdminHub router cache invalidation logic."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from freeadmin.hub import AdminHub
+
+
+def _build_hub(router: MagicMock | None = None) -> AdminHub:
+    """Return a minimally initialised ``AdminHub`` for cache tests."""
+
+    hub = object.__new__(AdminHub)
+    hub._settings = MagicMock()
+    hub.admin_site = MagicMock()
+    hub.discovery = MagicMock()
+    hub._app_configs = {}
+    hub._started_configs = set()
+    hub._router = router
+    return hub  # type: ignore[return-value]
+
+
+def test_autodiscover_invalidates_router_when_new_configured() -> None:
+    """New discoveries should drop cached router wrappers."""
+
+    aggregator = MagicMock()
+    router = MagicMock()
+    router.aggregator = aggregator
+    hub = _build_hub(router)
+
+    new_config = SimpleNamespace(import_path="example.pkg")
+    hub.discovery.discover_all.return_value = [new_config]
+
+    discovered = hub.autodiscover(["example"])
+
+    assert discovered == [new_config]
+    aggregator.invalidate_admin_router.assert_called_once_with()
+    assert hub._app_configs["example.pkg"] is new_config
+    assert hub._router is None
+
+
+def test_autodiscover_preserves_router_for_existing_configs() -> None:
+    """Discovering previously known configs must keep the cache intact."""
+
+    aggregator = MagicMock()
+    router = MagicMock()
+    router.aggregator = aggregator
+    existing = SimpleNamespace(import_path="example.pkg")
+    hub = _build_hub(router)
+    hub._app_configs = {existing.import_path: existing}
+
+    duplicate_config = SimpleNamespace(import_path="example.pkg")
+    hub.discovery.discover_all.return_value = [duplicate_config]
+
+    discovered = hub.autodiscover(["example"])
+
+    assert discovered == [duplicate_config]
+    aggregator.invalidate_admin_router.assert_not_called()
+    assert hub._router is router
+
+
+@pytest.mark.parametrize("packages", [[], tuple()])
+def test_autodiscover_no_packages_returns_empty(packages) -> None:
+    """No discovery roots should lead to no router changes."""
+
+    aggregator = MagicMock()
+    router = MagicMock()
+    router.aggregator = aggregator
+    hub = _build_hub(router)
+
+    discovered = hub.autodiscover(packages)
+
+    assert discovered == []
+    aggregator.invalidate_admin_router.assert_not_called()
+    assert hub._router is router


### PR DESCRIPTION
## Summary
- extract a shared router foundation to centralize TemplateProvider setup and static mounting, and wrap AdminRouter around RouterAggregator
- update AdminHub and ApplicationFactory to reuse a cached AdminRouter instance when mounting FastAPI apps
- extend router aggregator tests and refresh documentation to reflect the aggregator-backed behaviour

## Testing
- pytest freeadmin/tests/test_router_aggregator.py

------
https://chatgpt.com/codex/tasks/task_e_68efde3c012083308b1b8f96b3dd761d