### PR TITLE
Relocate template modules under core templates package

### DIFF
--- a/freeadmin/core/templates/__init__.py
+++ b/freeadmin/core/templates/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+"""
+core.templates
+
+Public exports for FreeAdmin core templating utilities.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from .rendering import TemplateRenderer, render_template
+from .service import DEFAULT_TEMPLATE_SERVICE, TemplateService
+
+
+# The End
+
+

--- a/freeadmin/core/templates/service.py
+++ b/freeadmin/core/templates/service.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+"""
+core.templates.service
+
+Shared template service coordinating providers, caching, and mounting.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from weakref import WeakSet
+
+from fastapi import FastAPI
+from fastapi.templating import Jinja2Templates
+
+from ...conf import FreeAdminSettings, current_settings
+from ...provider import TemplateProvider
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checking only
+    from ..site import AdminSite
+
+
+ASSETS_DIR = Path(__file__).resolve().parent.parent.parent / "static"
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent.parent / "templates"
+
+
+class TemplateService:
+    """Manage template providers, caching, and static mounts for FreeAdmin."""
+
+    def __init__(
+        self,
+        *,
+        templates_dir: str | Path | None = None,
+        static_dir: str | Path | None = None,
+        settings: FreeAdminSettings | None = None,
+        provider_cls: type[TemplateProvider] = TemplateProvider,
+    ) -> None:
+        """Configure the service with template locations and settings."""
+
+        self._templates_dir = str(templates_dir or TEMPLATES_DIR)
+        self._static_dir = str(static_dir or ASSETS_DIR)
+        self._settings = settings or current_settings()
+        self._provider_cls = provider_cls
+        self._provider: TemplateProvider | None = None
+        self._templates: Jinja2Templates | None = None
+        self._mounted_apps: WeakSet[FastAPI] = WeakSet()
+
+    def get_provider(self) -> TemplateProvider:
+        """Return the cached template provider, creating it when needed."""
+
+        if self._provider is None:
+            self._provider = self._provider_cls(
+                templates_dir=self._templates_dir,
+                static_dir=self._static_dir,
+                settings=self._settings,
+            )
+        return self._provider
+
+    def get_templates(self) -> Jinja2Templates:
+        """Return the cached ``Jinja2Templates`` environment."""
+
+        if self._templates is None:
+            self._templates = self.get_provider().get_templates()
+        return self._templates
+
+    def ensure_site_templates(self, site: "AdminSite") -> None:
+        """Ensure the provided admin ``site`` exposes the shared templates."""
+
+        if site.templates is None:
+            site.templates = self.get_templates()
+
+    def mount_static_resources(self, app: FastAPI, prefix: str) -> None:
+        """Mount static, favicon, and media resources once per application."""
+
+        if app in self._mounted_apps:
+            return
+
+        provider = self.get_provider()
+        provider.mount_static(app, prefix)
+        provider.mount_favicon(app)
+        provider.mount_media(app)
+        self._mounted_apps.add(app)
+
+
+DEFAULT_TEMPLATE_SERVICE = TemplateService()
+
+
+# The End
+

--- a/freeadmin/router/aggregator.py
+++ b/freeadmin/router/aggregator.py
@@ -19,6 +19,7 @@ from fastapi import APIRouter, FastAPI
 from ..conf import FreeAdminSettings
 from ..core.settings import SettingsKey, system_config
 from ..core.site import AdminSite
+from ..core.templates import TemplateService
 from .base import RouterFoundation
 
 
@@ -32,10 +33,11 @@ class RouterAggregator(RouterFoundation):
         *,
         settings: FreeAdminSettings | None = None,
         additional_routers: Iterable[tuple[APIRouter, str | None]] | None = None,
+        template_service: TemplateService | None = None,
     ) -> None:
         """Initialise the aggregator with the admin site and base settings."""
 
-        super().__init__(settings=settings)
+        super().__init__(settings=settings, template_service=template_service)
         self.site = site
         default_prefix = system_config.get_cached(
             SettingsKey.ADMIN_PREFIX, self._settings.admin_path
@@ -56,7 +58,7 @@ class RouterAggregator(RouterFoundation):
     def create_admin_router(self) -> APIRouter:
         """Instantiate the FastAPI router for the admin site."""
 
-        return self.site.build_router(self._provider)
+        return self.site.build_router(self.provider)
 
     def get_admin_router(self) -> APIRouter:
         """Return the cached admin router, creating it when necessary."""
@@ -119,6 +121,7 @@ class ExtendedRouterAggregator(RouterAggregator):
         settings: FreeAdminSettings | None = None,
         additional_routers: Iterable[tuple[APIRouter, str | None]] | None = None,
         public_first: bool = True,
+        template_service: TemplateService | None = None,
     ) -> None:
         """Initialise the aggregator and configure registration order."""
 
@@ -127,6 +130,7 @@ class ExtendedRouterAggregator(RouterAggregator):
             prefix=prefix,
             settings=settings,
             additional_routers=additional_routers,
+            template_service=template_service,
         )
         self._public_first = public_first
         self._public_routers: list[APIRouter] = []

--- a/freeadmin/templates/__init__.py
+++ b/freeadmin/templates/__init__.py
@@ -9,7 +9,7 @@ Author: Timur Kady
 Email: timurkady@yandex.com
 """
 
-from .rendering import TemplateRenderer, render_template
+from ..core.templates import TemplateRenderer, TemplateService, render_template
 
 
 # The End

--- a/freeadmin/tests/test_template_renderer.py
+++ b/freeadmin/tests/test_template_renderer.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+"""
+tests.test_template_renderer
+
+Unit tests for the shared template rendering service.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from freeadmin.core.templates import TemplateRenderer, TemplateService
+
+
+class DummyTemplates:
+    """Collect template rendering calls for assertions."""
+
+    def __init__(self) -> None:
+        """Initialise the call history container."""
+
+        self.calls: list[tuple[str, Mapping[str, Any]]] = []
+
+    def TemplateResponse(self, template_name: str, context: Mapping[str, Any]) -> dict[str, Any]:
+        """Record the call and echo a serialisable response."""
+
+        self.calls.append((template_name, context))
+        return {"template": template_name, "context": context}
+
+
+class TrackingProvider:
+    """Minimal provider used to validate service caching."""
+
+    def __init__(
+        self,
+        *,
+        templates_dir: str,
+        static_dir: str,
+        settings: Any,
+    ) -> None:
+        """Create the provider with inert template and static references."""
+
+        del templates_dir, static_dir, settings
+        self.templates = DummyTemplates()
+        self.get_templates_calls = 0
+
+    def get_templates(self) -> DummyTemplates:
+        """Return the dummy templates while tracking call frequency."""
+
+        self.get_templates_calls += 1
+        return self.templates
+
+    def mount_static(self, *_: Any, **__: Any) -> None:
+        """Stub implementation to satisfy the provider interface."""
+
+    def mount_favicon(self, *_: Any, **__: Any) -> None:
+        """Stub implementation to satisfy the provider interface."""
+
+    def mount_media(self, *_: Any, **__: Any) -> None:
+        """Stub implementation to satisfy the provider interface."""
+
+
+def test_template_renderer_uses_shared_service_cache() -> None:
+    """Template renderer should reuse the cached templates instance."""
+
+    service = TemplateService(provider_cls=TrackingProvider)
+    original_service = TemplateRenderer.get_service()
+    TemplateRenderer.configure(service)
+
+    try:
+        first = TemplateRenderer.render(
+            "welcome.html",
+            {"request": object(), "message": "hello"},
+        )
+        second = TemplateRenderer.render(
+            "welcome.html",
+            {"request": object(), "message": "again"},
+        )
+
+        provider = service.get_provider()
+        assert provider.get_templates_calls == 1
+        assert provider.templates.calls[0][1]["message"] == "hello"
+        assert provider.templates.calls[1][1]["message"] == "again"
+        assert first["context"]["message"] == "hello"
+        assert second["context"]["message"] == "again"
+    finally:
+        TemplateRenderer.configure(original_service)
+
+
+# The End
+


### PR DESCRIPTION
## Summary
- move the shared template service and renderer into a new `freeadmin.core.templates` package
- update router infrastructure, public exports, and tests to consume the relocated package and refreshed paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68efee4190908330961656a7259dafb5