### PR TITLE
Add centralized page descriptor management for admin and public pages

### DIFF
--- a/freeadmin/core/pages.py
+++ b/freeadmin/core/pages.py
@@ -11,9 +11,17 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple, TYPE_CHECKING
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse
 
 from .settings import SettingsKey, system_config
+from .auth import admin_auth_service
+from .services.permissions import PermAction
+
+if TYPE_CHECKING:  # pragma: no cover - typing helpers only
+    from .site import AdminSite
 
 
 @dataclass(frozen=True)
@@ -63,5 +71,577 @@ class SettingsPage(FreeViewPage):
             SettingsKey.PAGE_TYPE_SETTINGS, "settings"
         )
     )
+
+
+@dataclass
+class PageResolution:
+    """Describe how a URL path maps onto the admin navigation tree."""
+
+    normalized_path: str
+    section_mode: str
+    is_settings: bool
+    app_label: str | None
+    model_slug: str | None
+    descriptor: "PageDescriptor | None"
+
+
+@dataclass
+class PageDescriptor:
+    """Store metadata for registered admin, settings, or public pages."""
+
+    manager: "PageDescriptorManager"
+    title: str
+    path: str
+    icon: str | None
+    normalized_path: str
+    normalized_key: str
+    owning_label: str
+    section: str
+    include_in_sidebar: bool
+    has_required_tail: bool
+    settings: bool
+    model_name: str
+    app_label: str | None
+    app_slug: str | None
+    slug: str | None
+    dotted: str | None
+    page_class: type[AdminPage]
+    menu_page_type: str | None = None
+    template_name: str | None = None
+    public: bool = False
+    handler: Callable[..., Any] | None = None
+    page: AdminPage | None = None
+
+    def bind_handler(self, func: Callable[..., Any]) -> Callable[..., Any]:
+        """Attach ``func`` as the handler for the registered page."""
+
+        self.handler = func
+        site = self.manager.admin_site
+        if issubclass(self.page_class, FreeViewPage):
+            page_kwargs = {
+                "title": self.title,
+                "path": self.normalized_path,
+                "icon": self.icon,
+                "handler": func,
+                "app_label": self.app_label,
+                "app_slug": self.app_slug,
+                "slug": self.slug,
+                "dotted": self.dotted,
+            }
+            self.page = self.page_class(**page_kwargs)  # type: ignore[arg-type]
+            site.registry.register_page(self.page)
+            site.menu_builder.register_item(
+                title=self.title,
+                path=self.normalized_path,
+                icon=self.icon,
+                page_type=self.menu_page_type,
+            )
+            site.menu_builder.invalidate_main_menu()
+        return func
+
+    def build_sidebar_entry(self) -> Dict[str, Any]:
+        """Return sidebar entry payload for the descriptor."""
+
+        return {
+            "model_name": self.model_name,
+            "display_name": self.title,
+            "path": self.normalized_path,
+            "icon": self.icon,
+            "settings": self.settings,
+        }
+
+    def mount_admin_route(
+        self,
+        router: APIRouter,
+        *,
+        templates,
+        page_type_settings: str,
+        views_prefix: str,
+        settings_prefix: str,
+        orm_prefix: str,
+    ) -> None:
+        """Attach the descriptor as a GET route under the admin router."""
+
+        page = self.page
+        if not isinstance(page, FreeViewPage):
+            return
+        site = self.manager.admin_site
+        user_dependency = (
+            admin_auth_service.get_current_admin_user
+            if page.page_type == page_type_settings
+            else admin_auth_service.require_permissions((), admin_site=site)
+        )
+        registry_virtual = site.registry.get_view_virtual_by_path(page.path)
+        dotted_key = page.dotted or (registry_virtual.dotted if registry_virtual else None)
+        perm_dep = site.permission_checker.require_view(
+            PermAction.view,
+            dotted=dotted_key,
+            view_key=page.path if dotted_key is None else None,
+            admin_site=site,
+        )
+
+        async def endpoint(
+            request: Request,
+            page: FreeViewPage = Depends(lambda page=page: page),
+            user=Depends(user_dependency),
+            _perm=Depends(perm_dep),
+        ) -> HTMLResponse:
+            ctx: Dict[str, Any] = {}
+            if page.handler:
+                result = page.handler(request=request, user=user)
+                if hasattr(result, "__await__"):
+                    result = await result  # type: ignore[func-returns-value]
+                if isinstance(result, Mapping):
+                    ctx = dict(result)
+            is_settings = (
+                page.page_type == page_type_settings
+                or page.path == settings_prefix
+            )
+            if page.path == orm_prefix:
+                template_name = "pages/orm.html"
+            elif page.path == settings_prefix:
+                template_name = "pages/settings.html"
+            elif page.path == views_prefix:
+                template_name = "pages/views.html"
+            else:
+                template_name = "layout/section.html"
+            base_ctx = site.build_template_ctx(
+                request,
+                user,
+                page_title=page.title,
+                is_settings=is_settings,
+                extra=ctx,
+            )
+            if page.path != views_prefix:
+                base_ctx["menu"] = site.menu_builder.build_main_menu(
+                    locale=site.get_locale(request)
+                )
+            return templates.TemplateResponse(template_name, base_ctx)
+
+        router.add_api_route(
+            page.path, endpoint, methods=["GET"], name=page.title
+        )
+
+    def mount_public_route(self, router: APIRouter) -> None:
+        """Attach the descriptor as an anonymous page under ``router``."""
+
+        if not self.public or not self.template_name:
+            return
+        responder = self.manager.page_responder
+
+        async def endpoint(request: Request) -> HTMLResponse:
+            context: Dict[str, Any] = {}
+            if self.handler is not None:
+                result = self.handler(request=request, user=None)
+                if hasattr(result, "__await__"):
+                    result = await result  # type: ignore[func-returns-value]
+                if isinstance(result, Mapping):
+                    context = dict(result)
+            return responder.render(
+                self.template_name,
+                request=request,
+                context=context,
+                title=self.title,
+            )
+
+        router.add_api_route(
+            self.normalized_path,
+            endpoint,
+            methods=["GET"],
+            name=self.title,
+            response_class=HTMLResponse,
+        )
+
+
+class PageDescriptorManager:
+    """Coordinate admin, settings, and public page registrations."""
+
+    def __init__(self, admin_site: "AdminSite") -> None:
+        """Store ``admin_site`` and initialise descriptor collections."""
+
+        self._admin_site = admin_site
+        self._descriptors: Dict[str, PageDescriptor] = {}
+        self._public_descriptors: List[PageDescriptor] = []
+        self._public_router: APIRouter | None = None
+        self._public_router_dirty = False
+
+    @property
+    def admin_site(self) -> "AdminSite":
+        """Return the admin site the manager is bound to."""
+
+        return self._admin_site
+
+    @property
+    def admin_auth_service(self):  # pragma: no cover - attribute proxy
+        """Expose admin auth service from the owning site."""
+
+        return getattr(self._admin_site, "admin_auth_service")
+
+    @property
+    def page_responder(self):  # pragma: no cover - attribute proxy
+        """Return template responder used for public pages."""
+
+        from ..templates import PageTemplateResponder
+
+        return PageTemplateResponder
+
+    def register_view(
+        self,
+        *,
+        path: str,
+        name: str,
+        icon: str | None = None,
+        label: str | None = None,
+        settings: bool | None = None,
+        include_in_sidebar: bool = True,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Register an administrative view page."""
+
+        normalized_path = self._normalize_path(path)
+        slug_source = normalized_path.strip("/")
+        owning_label = label or (slug_source.split("/", 1)[0] if slug_source else None)
+        if owning_label is None:
+            owning_label = self._admin_site._model_to_slug(name)
+
+        settings_prefix = system_config.get_cached(SettingsKey.SETTINGS_PREFIX, "/settings")
+        views_prefix = system_config.get_cached(SettingsKey.VIEWS_PREFIX, "/views")
+        orm_prefix = system_config.get_cached(SettingsKey.ORM_PREFIX, "/orm")
+
+        derived_settings = settings
+        if derived_settings is None:
+            derived_settings = normalized_path.startswith(settings_prefix)
+
+        normalized_key = self._normalize_key(normalized_path)
+        section_prefixes = (
+            self._normalize_prefix(views_prefix),
+            self._normalize_prefix(orm_prefix),
+            self._normalize_prefix(settings_prefix),
+        )
+
+        has_required_tail = True
+        tail_segments: List[str] = []
+        for section_prefix in section_prefixes:
+            if normalized_key == section_prefix:
+                has_required_tail = False
+                break
+            if normalized_key.startswith(f"{section_prefix}/"):
+                tail = normalized_key[len(section_prefix) + 1 :]
+                tail_segments = [segment for segment in tail.split("/") if segment]
+                has_required_tail = len(tail_segments) >= 2
+                break
+
+        if not tail_segments and has_required_tail:
+            tail_segments = [segment for segment in slug_source.split("/") if segment]
+
+        app_segment: str | None = None
+        normalized_segments = [
+            self._admin_site._model_to_slug(segment) for segment in tail_segments
+        ]
+        if normalized_segments:
+            app_segment = normalized_segments[0]
+        if has_required_tail and app_segment is None and owning_label is not None:
+            app_segment = self._admin_site._model_to_slug(owning_label)
+
+        app_for_virtual = owning_label or app_segment or name
+        slug_seed = slug_source or name
+        virtual = self._admin_site.registry.register_view_virtual(
+            path=normalized_path,
+            app_label=str(app_for_virtual),
+            slug_source=str(slug_seed),
+        )
+        if app_segment is None:
+            app_segment = virtual.app_slug
+        owning_label = owning_label or virtual.app_label
+
+        section = self._classify_section(
+            normalized_key,
+            views_prefix,
+            orm_prefix,
+            settings_prefix,
+        )
+        model_name = (
+            slug_source.replace("/", "_")
+            if slug_source
+            else self._admin_site._model_to_slug(name)
+        )
+
+        descriptor = PageDescriptor(
+            manager=self,
+            title=name,
+            path=normalized_path,
+            icon=icon,
+            normalized_path=normalized_path,
+            normalized_key=normalized_key,
+            owning_label=owning_label,
+            section=section,
+            include_in_sidebar=include_in_sidebar,
+            has_required_tail=has_required_tail,
+            settings=bool(derived_settings),
+            model_name=model_name,
+            app_label=app_segment,
+            app_slug=virtual.app_slug,
+            slug=virtual.slug if virtual.slug else None,
+            dotted=virtual.dotted,
+            page_class=FreeViewPage,
+        )
+        self._descriptors[normalized_key] = descriptor
+
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            return descriptor.bind_handler(func)
+
+        return decorator
+
+    def register_settings(
+        self,
+        *,
+        path: str,
+        name: str,
+        icon: str | None = None,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Register a settings page under the settings section."""
+
+        normalized_path = self._normalize_path(path)
+        normalized_key = self._normalize_key(normalized_path)
+        page_type_settings = system_config.get_cached(
+            SettingsKey.PAGE_TYPE_SETTINGS, "settings"
+        )
+        settings_prefix = system_config.get_cached(SettingsKey.SETTINGS_PREFIX, "/settings")
+        has_required_tail = (
+            normalized_key
+            != self._normalize_prefix(settings_prefix)
+        )
+        virtual = self._admin_site.registry.register_view_virtual(
+            path=normalized_path,
+            app_label="settings",
+            slug_source=name,
+        )
+
+        descriptor = PageDescriptor(
+            manager=self,
+            title=name,
+            path=normalized_path,
+            icon=icon,
+            normalized_path=normalized_path,
+            normalized_key=normalized_key,
+            owning_label=virtual.app_label,
+            section="settings",
+            include_in_sidebar=True,
+            has_required_tail=has_required_tail,
+            settings=True,
+            model_name=virtual.slug,
+            app_label=virtual.app_slug,
+            app_slug=virtual.app_slug,
+            slug=virtual.slug,
+            dotted=virtual.dotted,
+            page_class=SettingsPage,
+            menu_page_type=page_type_settings,
+        )
+        self._descriptors[normalized_key] = descriptor
+
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            return descriptor.bind_handler(func)
+
+        return decorator
+
+    def register_public_view(
+        self,
+        *,
+        path: str,
+        name: str,
+        template: str,
+        icon: str | None = None,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Register a public page rendered outside the admin shell."""
+
+        normalized_path = self._normalize_path(path)
+        normalized_key = self._normalize_key(normalized_path)
+        descriptor = PageDescriptor(
+            manager=self,
+            title=name,
+            path=normalized_path,
+            icon=icon,
+            normalized_path=normalized_path,
+            normalized_key=normalized_key,
+            owning_label=name,
+            section="public",
+            include_in_sidebar=False,
+            has_required_tail=False,
+            settings=False,
+            model_name=name,
+            app_label=None,
+            app_slug=None,
+            slug=None,
+            dotted=None,
+            page_class=FreeViewPage,
+            template_name=template,
+            public=True,
+        )
+        self._public_descriptors.append(descriptor)
+        self._public_router_dirty = True
+
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            descriptor.handler = func
+            return func
+
+        return decorator
+
+    def iter_sidebar_views(
+        self, *, settings: bool
+    ) -> List[Tuple[str, List[Dict[str, Any]]]]:
+        """Return sidebar groupings for registered views."""
+
+        grouped: Dict[str, List[Dict[str, Any]]] = {}
+        for descriptor in self._descriptors.values():
+            if descriptor.public:
+                continue
+            if not descriptor.include_in_sidebar or not descriptor.has_required_tail:
+                continue
+            if descriptor.settings != settings:
+                continue
+            grouped.setdefault(descriptor.owning_label, []).append(
+                descriptor.build_sidebar_entry()
+            )
+
+        items: List[Tuple[str, List[Dict[str, Any]]]] = []
+        for label, entries in grouped.items():
+            entries.sort(key=lambda item: item["display_name"].lower())
+            items.append((label, entries))
+        items.sort(key=lambda item: item[0].lower())
+        return items
+
+    def resolve_request(self, request: Request) -> PageResolution:
+        """Analyse ``request`` to determine the active navigation context."""
+
+        admin_prefix = system_config.get_cached(
+            SettingsKey.ADMIN_PREFIX, self._admin_site._settings.admin_path
+        ).rstrip("/")
+        trimmed_path = request.url.path
+        if admin_prefix and trimmed_path.startswith(admin_prefix):
+            trimmed_path = trimmed_path[len(admin_prefix) :]
+            if not trimmed_path.startswith("/"):
+                trimmed_path = f"/{trimmed_path}"
+
+        normalized_path = trimmed_path.rstrip("/") or "/"
+        views_prefix = system_config.get_cached(SettingsKey.VIEWS_PREFIX, "/views")
+        orm_prefix = system_config.get_cached(SettingsKey.ORM_PREFIX, "/orm")
+        settings_prefix = system_config.get_cached(SettingsKey.SETTINGS_PREFIX, "/settings")
+        normalized_views = self._normalize_prefix(views_prefix)
+        normalized_orm = self._normalize_prefix(orm_prefix)
+        normalized_settings = self._normalize_prefix(settings_prefix)
+
+        section_mode = "views"
+        if normalized_path == normalized_settings or normalized_path.startswith(
+            f"{normalized_settings}/"
+        ):
+            section_mode = "settings"
+        elif normalized_path == normalized_orm or normalized_path.startswith(
+            f"{normalized_orm}/"
+        ):
+            section_mode = "orm"
+        elif normalized_path == normalized_views or normalized_path.startswith(
+            f"{normalized_views}/"
+        ):
+            section_mode = "views"
+
+        is_settings = section_mode == "settings"
+        app_label: Optional[str] = None
+        model_slug: Optional[str] = None
+
+        segments = [
+            segment for segment in normalized_path.strip("/").split("/") if segment
+        ]
+        if section_mode in {"orm", "settings"} and len(segments) >= 2:
+            app_label = segments[1]
+            if len(segments) >= 3:
+                model_slug = segments[2]
+
+        descriptor = self._descriptors.get(normalized_path)
+        if descriptor is not None:
+            section_mode = descriptor.section
+            if descriptor.settings:
+                is_settings = True
+            if descriptor.app_label:
+                app_label = descriptor.app_label
+            if descriptor.slug:
+                model_slug = descriptor.slug
+
+        return PageResolution(
+            normalized_path=normalized_path,
+            section_mode=section_mode,
+            is_settings=is_settings,
+            app_label=app_label,
+            model_slug=model_slug,
+            descriptor=descriptor,
+        )
+
+    def attach_admin_routes(
+        self,
+        router: APIRouter,
+        *,
+        templates,
+        page_type_settings: str,
+        views_prefix: str,
+        settings_prefix: str,
+        orm_prefix: str,
+    ) -> None:
+        """Mount registered admin pages onto ``router``."""
+
+        for descriptor in list(self._descriptors.values()):
+            if descriptor.public:
+                continue
+            descriptor.mount_admin_route(
+                router,
+                templates=templates,
+                page_type_settings=page_type_settings,
+                views_prefix=views_prefix,
+                settings_prefix=settings_prefix,
+                orm_prefix=orm_prefix,
+            )
+
+    def iter_public_routers(self) -> Iterable[APIRouter]:
+        """Yield routers exposing registered public pages."""
+
+        if not self._public_descriptors:
+            return ()
+        if self._public_router is None or self._public_router_dirty:
+            router = APIRouter()
+            for descriptor in self._public_descriptors:
+                descriptor.mount_public_route(router)
+            self._public_router = router
+            self._public_router_dirty = False
+        return (self._public_router,)
+
+    @staticmethod
+    def _normalize_path(path: str) -> str:
+        return path if path.startswith("/") else f"/{path}"
+
+    @staticmethod
+    def _normalize_key(path: str) -> str:
+        return path.rstrip("/") or "/"
+
+    @staticmethod
+    def _normalize_prefix(prefix: str) -> str:
+        cleaned = prefix if prefix.startswith("/") else f"/{prefix}"
+        return cleaned.rstrip("/") or "/"
+
+    def _classify_section(
+        self,
+        normalized_key: str,
+        views_prefix: str,
+        orm_prefix: str,
+        settings_prefix: str,
+    ) -> str:
+        normalized_views = self._normalize_prefix(views_prefix)
+        normalized_orm = self._normalize_prefix(orm_prefix)
+        normalized_settings = self._normalize_prefix(settings_prefix)
+        if normalized_key == normalized_settings or normalized_key.startswith(
+            f"{normalized_settings}/"
+        ):
+            return "settings"
+        if normalized_key == normalized_orm or normalized_key.startswith(
+            f"{normalized_orm}/"
+        ):
+            return "orm"
+        return "views"
 
 # The End

--- a/freeadmin/core/pages.py
+++ b/freeadmin/core/pages.py
@@ -529,7 +529,7 @@ class PageDescriptorManager:
         normalized_orm = self._normalize_prefix(orm_prefix)
         normalized_settings = self._normalize_prefix(settings_prefix)
 
-        section_mode = "views"
+        section_mode = "orm"
         if normalized_path == normalized_settings or normalized_path.startswith(
             f"{normalized_settings}/"
         ):

--- a/freeadmin/core/templates/__init__.py
+++ b/freeadmin/core/templates/__init__.py
@@ -9,7 +9,7 @@ Author: Timur Kady
 Email: timurkady@yandex.com
 """
 
-from .rendering import TemplateRenderer, render_template
+from .rendering import PageTemplateResponder, TemplateRenderer, render_template
 from .service import DEFAULT_TEMPLATE_SERVICE, TemplateService
 
 

--- a/freeadmin/core/templates/rendering.py
+++ b/freeadmin/core/templates/rendering.py
@@ -55,6 +55,28 @@ class TemplateRenderer:
         return templates.TemplateResponse(template_name, final_context)
 
 
+class PageTemplateResponder:
+    """Render FreeAdmin page templates with standardised context defaults."""
+
+    @classmethod
+    def render(
+        cls,
+        template_name: str,
+        *,
+        request: Request,
+        context: Mapping[str, Any] | None = None,
+        title: str | None = None,
+    ) -> HTMLResponse:
+        """Render ``template_name`` using ``context`` and injected defaults."""
+
+        payload = dict(context or {})
+        payload.setdefault("request", request)
+        payload.setdefault("user", getattr(request.state, "user", None))
+        if title is not None:
+            payload.setdefault("title", title)
+        return TemplateRenderer.render(template_name, payload, request=request)
+
+
 def render_template(
     template_name: str,
     context: Mapping[str, Any],

--- a/freeadmin/pages/example_welcome_page.py
+++ b/freeadmin/pages/example_welcome_page.py
@@ -11,20 +11,20 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse
+from fastapi import Request
 
-from freeadmin.templates import render_template
-
-router = APIRouter()
+from freeadmin.hub import admin_site
 
 
-@router.get("/", response_class=HTMLResponse)
-async def index(request: Request) -> HTMLResponse:
-    """Render the welcome page example for anonymous visitors."""
+@admin_site.register_public_view(
+    path="/",
+    name="Welcome",
+    template="welcome.html",
+)
+async def index(request: Request, user: object | None = None) -> dict[str, object]:
+    """Return template context for the welcome example page."""
 
-    context = {"request": request, "title": "Welcome", "user": None}
-    return render_template("welcome.html", context)
+    return {"request": request, "user": user}
 
 
 # The End

--- a/freeadmin/router/aggregator.py
+++ b/freeadmin/router/aggregator.py
@@ -92,6 +92,8 @@ class RouterAggregator(RouterFoundation):
 
         for router, router_prefix in self._iter_additional_routers():
             app.include_router(router, prefix=router_prefix or "")
+        for router in self.get_public_routers():
+            app.include_router(router, prefix="")
 
     def add_additional_router(
         self, router: APIRouter, prefix: str | None = None
@@ -104,6 +106,11 @@ class RouterAggregator(RouterFoundation):
         """Return routers that should be mounted alongside the admin router."""
 
         return ()
+
+    def get_public_routers(self) -> Iterable[APIRouter]:
+        """Return routers exposing public pages registered on the site."""
+
+        return self.site.pages.iter_public_routers()
 
     def _iter_additional_routers(self) -> Iterable[tuple[APIRouter, str | None]]:
         yield from self._additional_routers
@@ -168,6 +175,7 @@ class ExtendedRouterAggregator(RouterAggregator):
         self.ensure_site_templates(self.site)
         admin_entries = self._collect_admin_entries()
         public_entries = [(router, None) for router in self._public_routers]
+        public_entries.extend((router, None) for router in self.get_public_routers())
         if self._public_first:
             return [*public_entries, *admin_entries]
         return [*admin_entries, *public_entries]

--- a/freeadmin/templates/__init__.py
+++ b/freeadmin/templates/__init__.py
@@ -9,7 +9,12 @@ Author: Timur Kady
 Email: timurkady@yandex.com
 """
 
-from ..core.templates import TemplateRenderer, TemplateService, render_template
+from ..core.templates import (
+    PageTemplateResponder,
+    TemplateRenderer,
+    TemplateService,
+    render_template,
+)
 
 
 # The End

--- a/tests/test_public_pages.py
+++ b/tests/test_public_pages.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""public pages
+
+Test coverage for registering and exposing public FreeAdmin pages."""
+
+from __future__ import annotations
+
+from freeadmin.boot import admin as boot_admin
+from freeadmin.core.site import AdminSite
+from freeadmin.router.aggregator import ExtendedRouterAggregator
+from tests.conftest import admin_state
+
+
+class TestPublicPageRegistration:
+    """Validate registration and mounting of public pages."""
+
+    site: AdminSite
+
+    @classmethod
+    def setup_class(cls) -> None:
+        """Prepare a fresh admin site and register a public page."""
+
+        admin_state.reset()
+        cls.site = AdminSite(boot_admin.adapter, title="Public Page Test")
+
+        @cls.site.register_public_view(
+            path="/welcome",
+            name="Welcome",
+            template="welcome.html",
+        )
+        async def welcome(request, user=None) -> dict[str, object]:
+            """Provide additional context for the welcome page."""
+
+            return {"subtitle": "Rendered from tests", "user": user}
+
+    @classmethod
+    def teardown_class(cls) -> None:
+        """Restore the global admin state after tests complete."""
+
+        admin_state.reset()
+
+    def test_public_router_registration(self) -> None:
+        """Ensure the page manager exposes routers for public pages."""
+
+        routers = list(self.site.pages.iter_public_routers())
+        assert len(routers) == 1
+        router = routers[0]
+        paths = sorted(getattr(route, "path", "") for route in router.routes)
+        assert "/welcome" in paths
+
+    def test_extended_aggregator_includes_public_routes(self) -> None:
+        """Verify aggregated routers include registered public pages."""
+
+        aggregator = ExtendedRouterAggregator(site=self.site)
+        aggregator.add_admin_router(aggregator.get_admin_router())
+        collected_routes: list[str] = []
+        for router, prefix in aggregator.get_routers():
+            if prefix not in (None, ""):
+                continue
+            for route in router.routes:
+                path = getattr(route, "path", None)
+                if path:
+                    collected_routes.append(path)
+        assert "/welcome" in collected_routes
+
+
+# The End
+


### PR DESCRIPTION
## Summary
- introduce PageDescriptorManager to normalize admin, settings, and public page registration
- update template and sidebar builders plus router aggregators to leverage the unified page descriptors
- add public page renderer, documentation, and tests covering automatic public route exposure

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eff89fbb9c8330be62edd95777b1a2