### PR TITLE
Restore compatibility shim for CRUD imports

### DIFF
--- a/freeadmin/crud.py
+++ b/freeadmin/crud.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+"""crud
+
+Compatibility facade exposing CRUD helpers.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from __future__ import annotations
+
+from .contrib.crud import CrudRouterBuilder
+
+__all__ = ["CrudRouterBuilder"]
+
+
+# The End
+


### PR DESCRIPTION
## Summary
- add a compatibility module at `freeadmin.crud` that re-exports the CRUD helpers relocated to `freeadmin.contrib`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f0134f94e883308f88168fc61238e8