### PR TITLE
Align imports with new module layout and refresh CLI

### DIFF
--- a/freeadmin/__init__.py
+++ b/freeadmin/__init__.py
@@ -8,12 +8,12 @@ Author: Timur Kady
 Email: timurkady@yandex.com
 """
 
-from .application import ApplicationFactory
-from .conf import FreeAdminSettings, configure, current_settings
-from .core.base import BaseModelAdmin
-from .core.site import AdminSite
+from .core.application import ApplicationFactory
+from .core.configuration.conf import FreeAdminSettings, configure, current_settings
+from .core.interface.base import BaseModelAdmin
+from .core.interface.site import AdminSite
+from .core.network.router import AdminRouter
 from .meta import __version__
-from .router import AdminRouter
 
 # The End
 

--- a/freeadmin/api/cards.py
+++ b/freeadmin/api/cards.py
@@ -11,7 +11,7 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 
-from freeadmin.contrib.api.cards import public_router
+from ..contrib.api.cards import public_router
 
 __all__ = ["public_router"]
 

--- a/freeadmin/boot/registry.py
+++ b/freeadmin/boot/registry.py
@@ -11,7 +11,12 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 
-from freeadmin.core.boot.registry import LOGGER, ModelModuleRegistry, ModelRegistrar, import_module
+from ..core.boot.registry import (
+    LOGGER,
+    ModelModuleRegistry,
+    ModelRegistrar,
+    import_module,
+)
 
 __all__ = ["LOGGER", "ModelModuleRegistry", "ModelRegistrar", "import_module"]
 

--- a/freeadmin/contrib/apps/system/admin.py
+++ b/freeadmin/contrib/apps/system/admin.py
@@ -11,11 +11,11 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 
-from freeadmin.core.models import ModelAdmin
-from freeadmin.hub import admin_site
-from freeadmin.widgets import Select2Widget
+from ....core.interface.models import ModelAdmin
+from ....core.runtime.hub import admin_site
+from ....widgets import Select2Widget
 
-from freeadmin.boot import admin as boot_admin
+from ....core.boot import admin as boot_admin
 
 AdminGroup = boot_admin.adapter.group_model
 AdminGroupPermission = boot_admin.adapter.group_permission_model

--- a/freeadmin/contrib/apps/system/api/views.py
+++ b/freeadmin/contrib/apps/system/api/views.py
@@ -16,25 +16,25 @@ from typing import Literal
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
 
-from freeadmin.contrib.adapters import BaseAdapter
-from freeadmin.boot import admin as boot_admin
-from freeadmin.conf import (
+from ....adapters import BaseAdapter
+from .....core.boot import admin as boot_admin
+from .....conf import (
     FreeAdminSettings,
     current_settings,
     register_settings_observer,
 )
-from freeadmin.core.exceptions import (
+from .....core.exceptions import (
     ActionNotFound,
     AdminModelNotFound,
     HTTPError,
     PermissionDenied,
 )
-from freeadmin.core.permissions import permission_checker
-from freeadmin.core.services import PermAction, ScopeQueryService
-from freeadmin.core.services.auth import AdminUserDTO
-from freeadmin.core.services.tokens import ScopeTokenService
-from freeadmin.core.interface.settings import SettingsKey, system_config
-from freeadmin.runner import admin_action_runner
+from .....core.interface.permissions import permission_checker
+from .....core.interface.services import PermAction, ScopeQueryService
+from .....core.interface.services.auth import AdminUserDTO
+from .....core.interface.services.tokens import ScopeTokenService
+from .....core.interface.settings import SettingsKey, system_config
+from .....core.runtime.runner import admin_action_runner
 
 
 class AdminAPIConfiguration:

--- a/freeadmin/contrib/apps/system/apps.py
+++ b/freeadmin/contrib/apps/system/apps.py
@@ -16,7 +16,7 @@ from typing import ClassVar, TYPE_CHECKING
 from .urls import SystemURLRegistrar
 
 if TYPE_CHECKING:  # pragma: no cover - import for typing only
-    from freeadmin.core.interface.site import AdminSite
+    from ....core.interface.site import AdminSite
 
 
 class SystemAppConfig:

--- a/freeadmin/contrib/apps/system/models.py
+++ b/freeadmin/contrib/apps/system/models.py
@@ -11,7 +11,7 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 
-from freeadmin.boot import admin as boot_admin
+from ....core.boot import admin as boot_admin
 
 AdminUser = boot_admin.adapter.user_model
 AdminUserPermission = boot_admin.adapter.user_permission_model

--- a/freeadmin/contrib/apps/system/urls.py
+++ b/freeadmin/contrib/apps/system/urls.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 from .views import BuiltinPagesRegistrar, BuiltinUserMenuRegistrar
 
 if TYPE_CHECKING:  # pragma: no cover - import for typing only
-    from freeadmin.core.interface.site import AdminSite
+    from ....core.interface.site import AdminSite
 
 
 class SystemURLRegistrar:

--- a/freeadmin/contrib/apps/system/views.py
+++ b/freeadmin/contrib/apps/system/views.py
@@ -13,10 +13,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from freeadmin.core.interface.settings import SettingsKey, system_config
+from ....core.interface.settings import SettingsKey, system_config
 
 if TYPE_CHECKING:  # pragma: no cover - import for typing only
-    from freeadmin.core.interface.site import AdminSite
+    from ....core.interface.site import AdminSite
 
 
 class BuiltinPagesRegistrar:

--- a/freeadmin/core/actions/export_selected.py
+++ b/freeadmin/core/actions/export_selected.py
@@ -11,7 +11,7 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 
-from freeadmin.core.interface.actions.export_selected import ExportSelectedAction
+from ..interface.actions.export_selected import ExportSelectedAction
 
 __all__ = ["ExportSelectedAction"]
 

--- a/freeadmin/core/apps/system/__init__.py
+++ b/freeadmin/core/apps/system/__init__.py
@@ -11,7 +11,7 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 
-from freeadmin.contrib.apps.system.apps import SystemAppConfig
+from ....contrib.apps.system.apps import SystemAppConfig
 
 __all__ = ["SystemAppConfig"]
 

--- a/freeadmin/core/cache/cards.py
+++ b/freeadmin/core/cache/cards.py
@@ -11,7 +11,7 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 
-from freeadmin.core.interface.cache.cards import SQLiteCardCache
+from ..interface.cache.cards import SQLiteCardCache
 
 __all__ = ["SQLiteCardCache"]
 

--- a/freeadmin/core/cache/menu.py
+++ b/freeadmin/core/cache/menu.py
@@ -11,7 +11,7 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 
-from freeadmin.core.interface.cache.menu import MainMenuCache
+from ..interface.cache.menu import MainMenuCache
 
 __all__ = ["MainMenuCache"]
 

--- a/freeadmin/core/hub.py
+++ b/freeadmin/core/hub.py
@@ -11,7 +11,7 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 
-from freeadmin.core.runtime.hub import AdminHub, admin_site, hub
+from .runtime.hub import AdminHub, admin_site, hub
 
 __all__ = ["AdminHub", "admin_site", "hub"]
 

--- a/freeadmin/core/middleware.py
+++ b/freeadmin/core/middleware.py
@@ -11,7 +11,7 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 
-from freeadmin.core.runtime.middleware import AdminGuardMiddleware
+from .runtime.middleware import AdminGuardMiddleware
 
 __all__ = ["AdminGuardMiddleware"]
 

--- a/freeadmin/core/services/admin.py
+++ b/freeadmin/core/services/admin.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import sys
 
-from freeadmin.core.interface.services import admin as _admin_module
+from ..interface.services import admin as _admin_module
 
 sys.modules[__name__] = _admin_module
 

--- a/freeadmin/core/sse/publisher.py
+++ b/freeadmin/core/sse/publisher.py
@@ -11,7 +11,7 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 
-from freeadmin.core.interface.sse.publisher import PublisherService
+from ..interface.sse.publisher import PublisherService
 
 __all__ = ["PublisherService"]
 

--- a/freeadmin/pages/example_welcome_page.py
+++ b/freeadmin/pages/example_welcome_page.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from fastapi import Request
 
-from freeadmin.hub import admin_site
+from ..core.runtime.hub import admin_site
 
 
 @admin_site.register_public_view(

--- a/freeadmin/router/aggregator.py
+++ b/freeadmin/router/aggregator.py
@@ -11,7 +11,7 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 
-from freeadmin.core.network.router.aggregator import (
+from ..core.network.router.aggregator import (
     ExtendedRouterAggregator,
     RouterAggregator,
 )

--- a/freeadmin/utils/cli/__init__.py
+++ b/freeadmin/utils/cli/__init__.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from .application_scaffolder import ApplicationScaffolder
 from .commands import AddCommand, InitCommand, SuperuserCommand
 from .create_superuser import SuperuserCreator
-from .entrypoint import FreeAdminCLI, cli
+from .entry import FreeAdminCLI, cli
 from .project_initializer import ProjectInitializer
 from .reporting import CreationReport
 

--- a/freeadmin/utils/cli/create_superuser.py
+++ b/freeadmin/utils/cli/create_superuser.py
@@ -116,7 +116,7 @@ class SuperuserCreator:
             await user.set_password(raw_password)  # model handles hashing
         else:
             # In case someone removed set_password, do a last-resort direct set
-            from freeadmin.utils.passwords import password_hasher
+            from ..passwords import password_hasher
 
             user.password = await password_hasher.make_password(raw_password)
 

--- a/freeadmin/utils/cli/entry.py
+++ b/freeadmin/utils/cli/entry.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-cli
+entry
 
 Click entry point for the freeadmin toolkit.
 

--- a/freeadmin/utils/cli/project_initializer.py
+++ b/freeadmin/utils/cli/project_initializer.py
@@ -72,8 +72,8 @@ from typing import List
 
 from fastapi import FastAPI
 
-from freeadmin.boot import BootManager
-from freeadmin.orm import ORMConfig
+from freeadmin.core.boot import BootManager
+from freeadmin.core.data.orm import ORMConfig
 
 from .orm import ORM
 from .settings import ProjectSettings
@@ -140,7 +140,7 @@ from typing import Any, Dict
 from freeadmin.contrib.adapters.tortoise.adapter import (
     Adapter as TortoiseAdapter,
 )
-from freeadmin.orm import ORMConfig
+from freeadmin.core.data.orm import ORMConfig
 
 # Adjust the adapter name to match the backend registered with FreeAdmin.
 DB_ADAPTER = "tortoise"
@@ -244,9 +244,9 @@ from __future__ import annotations
 
 from fastapi import APIRouter, FastAPI
 
-from freeadmin.core.site import AdminSite
-from freeadmin.hub import admin_site
-from freeadmin.router import RouterAggregator
+from freeadmin.core.interface.site import AdminSite
+from freeadmin.core.runtime.hub import admin_site
+from freeadmin.core.network.router import RouterAggregator
 
 
 class {router_class}(RouterAggregator):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 ]
 
 [project.scripts]
-freeadmin = "freeadmin.cli:cli"
+freeadmin = "freeadmin.utils.cli.entry:cli"
 
 [project.urls]
 Homepage = "https://github.com/TimurKady/freeadmin"
@@ -73,4 +73,9 @@ exclude = [
 ]
 
 [tool.setuptools.package-data]
-freeadmin = ["static/**/*", "templates/**/*"]
+freeadmin = [
+    "static/**/*",
+    "templates/**/*",
+    "core/templates/**/*",
+    "core/interface/templates/**/*",
+]


### PR DESCRIPTION
## Summary
- update package wrappers and feature modules to import from the new core package locations
- replace the legacy CLI entrypoint with freeadmin.utils.cli.entry and refresh scaffolding templates to match
- expand packaged data patterns so relocated templates ship with the wheel and adjust the script entry point

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f011647a188330a56ac520a2bfd4dc