### PR TITLE
Update docs and example imports to new core layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Populate `apps/blog/models.py` and `apps/blog/admin.py` with your domain objects
 from tortoise import fields
 from tortoise.models import Model
 
-from freeadmin.core.models import ModelAdmin
+from freeadmin.core.interface.models import ModelAdmin
 from freeadmin.hub import admin_site
 
 
@@ -93,7 +93,7 @@ admin_site.register(app="blog", model=Post, admin_cls=PostAdmin)
 Initialise FreeAdmin inside your FastAPI application (usually in `config/main.py`):
 
 ```python
-from freeadmin.application import ApplicationFactory
+from freeadmin.core.application import ApplicationFactory
 
 
 application = ApplicationFactory()

--- a/docs/admin/APPLICATION_BOOTSTRAP.md
+++ b/docs/admin/APPLICATION_BOOTSTRAP.md
@@ -48,11 +48,11 @@ Create these files explicitly:
 
 ## 3. Implement `app.py`
 
-Each application exposes an `AppConfig` subclass and a module-level `default` instance. The base class lives in `freeadmin/core/app.py` and validates the configuration when instantiated. Create `apps/weather/app.py` with the following structure:
+Each application exposes an `AppConfig` subclass and a module-level `default` instance. The base class lives in `freeadmin/core/interface/app.py` and validates the configuration when instantiated. Create `apps/weather/app.py` with the following structure:
 
 ```python
 # apps/weather/app.py
-from freeadmin.core.app import AppConfig
+from freeadmin.core.interface.app import AppConfig
 from core.services.registry import ServiceRegistry  # project-specific registry helper
 from .service import WeatherService
 

--- a/docs/admin/adapter.md
+++ b/docs/admin/adapter.md
@@ -40,7 +40,7 @@ When the admin panel boots, it imports the desired adapter and exposes it via bo
 All database calls route through this object.
 
 ```python
-from freeadmin.boot import admin as boot_admin
+from freeadmin.core.boot import admin as boot_admin
 
 adapter = boot_admin.adapter
 ```

--- a/docs/admin/boot.md
+++ b/docs/admin/boot.md
@@ -9,7 +9,7 @@ built-in pages and mounts the admin site onto the ASGI application.
 ```python
 from fastapi import FastAPI
 from freeadmin.contrib.adapters import registry
-from freeadmin.boot import admin
+from freeadmin.core.boot import admin
 from my_project.adapters import MyAdapter
 
 app = FastAPI()

--- a/docs/admin/model_admin.md
+++ b/docs/admin/model_admin.md
@@ -23,7 +23,7 @@ Access to endpoints is handled via dependency injection (RBAC). ModelAdmin does 
 - `autocomplete_fields` — fields using autocomplete widgets. See [`BaseModelAdmin.get_autocomplete_fields`](../../contrib/admin/core/base.py#L199-L201) and [`get_autocomplete_queryset`](../../contrib/admin/core/base.py#L461-L482).
 
 ```python
-from freeadmin.core.models import ModelAdmin
+from freeadmin.core.interface.models import ModelAdmin
 from freeadmin.hub import admin_site
 from apps.authors.models import Author
 
@@ -71,7 +71,7 @@ admin_site.register(app="authors", model=Author, admin_cls=AuthorAdmin)
 Widgets can be provided as registry keys, widget classes, or pre‑instantiated objects. When an instance is supplied, `BaseModelAdmin` attaches the form context and reuses the same object, preserving any configuration.
 
 ```python
-from freeadmin.core.models import ModelAdmin
+from freeadmin.core.interface.models import ModelAdmin
 from freeadmin.widgets import TextWidget, TextAreaWidget
 
 

--- a/docs/admin/pages.md
+++ b/docs/admin/pages.md
@@ -17,8 +17,8 @@ skips section landing routes automatically, so the `include_in_sidebar` flag is
 optional when you reuse these defaults:
 
 ```python
-from freeadmin.core.site import AdminSite
-from freeadmin.core.settings import SettingsKey, system_config
+from freeadmin.core.interface.site import AdminSite
+from freeadmin.core.interface.settings import SettingsKey, system_config
 
 class BuiltinPagesRegistrar:
     def register(self, site: AdminSite) -> None:
@@ -139,7 +139,7 @@ pages:
 
 ```python
 # apps/articles/views/manage.py
-from freeadmin.core.site import AdminSite
+from freeadmin.core.interface.site import AdminSite
 
 
 class ArticleAdminViews:
@@ -194,7 +194,7 @@ built-in breadcrumbs will not reflect the current page. Update the prefix when
 you expose standalone views under a different URL root:
 
 ```python
-from freeadmin.core.settings import SettingsKey, system_config
+from freeadmin.core.interface.settings import SettingsKey, system_config
 
 await system_config.set(SettingsKey.VIEWS_PREFIX, "/console")
 ```
@@ -207,7 +207,7 @@ prefix.
 All page labels and icons are stored in `SystemSetting` and accessed through `SettingsKey` constants. Update them to change how built-in pages appear:
 
 ```python
-from freeadmin.core.settings import SettingsKey, system_config
+from freeadmin.core.interface.settings import SettingsKey, system_config
 
 await system_config.set(SettingsKey.VIEWS_PAGE_TITLE, "Custom Views")
 await system_config.set(SettingsKey.VIEWS_PAGE_ICON, "bi-star")

--- a/docs/admin/public-pages.md
+++ b/docs/admin/public-pages.md
@@ -67,8 +67,8 @@ administrative layout while remaining visually independent:
 ```python
 from fastapi import FastAPI
 
-from freeadmin.core.site import admin_site
-from freeadmin.router import ExtendedRouterAggregator
+from freeadmin.core.interface.site import admin_site
+from freeadmin.core.network.router import ExtendedRouterAggregator
 
 app = FastAPI()
 aggregator = ExtendedRouterAggregator(site=admin_site)
@@ -95,8 +95,8 @@ be registered via :meth:`ExtendedRouterAggregator.add_additional_router` when ne
 ```python
 from fastapi import FastAPI
 
-from freeadmin.core.site import admin_site
-from freeadmin.router import ExtendedRouterAggregator
+from freeadmin.core.interface.site import admin_site
+from freeadmin.core.network.router import ExtendedRouterAggregator
 
 app = FastAPI()
 

--- a/docs/admin/settings-mode.md
+++ b/docs/admin/settings-mode.md
@@ -12,8 +12,8 @@ This guide explains how the admin panel's settings mode differs from standard OR
 Use `AdminSite.register` with `settings=True` to mount a model under `/settings`:
 
 ```python
-from freeadmin.core.models import ModelAdmin
-from freeadmin.core.site import AdminSite
+from freeadmin.core.interface.models import ModelAdmin
+from freeadmin.core.interface.site import AdminSite
 
 class SiteConfigAdmin(ModelAdmin):
     model = SiteConfig

--- a/docs/admin/settings.md
+++ b/docs/admin/settings.md
@@ -5,7 +5,7 @@ The admin panel reads configuration values via the `SystemConfig` helper. Each o
 ## Working with `SystemConfig`
 
 ```python
-from freeadmin.core.settings.config import system_config, SettingsKey
+from freeadmin.core.interface.settings.config import system_config, SettingsKey
 
 # insert any missing defaults
 await system_config.ensure_seed()

--- a/docs/admin/user_menu.md
+++ b/docs/admin/user_menu.md
@@ -3,7 +3,7 @@
 `AdminSite.register_user_menu` attaches links to the user dropdown. Each entry requires a title and path and may include a Bootstrap icon class. The method stores the item in the registry so it becomes part of the context used by templates during rendering.
 
 ```python
-from freeadmin.core.site import AdminSite
+from freeadmin.core.interface.site import AdminSite
 
 class ExtraUserMenuRegistrar:
     def register(self, site: AdminSite) -> None:
@@ -16,7 +16,7 @@ Call the registrar before or after booting the admin application to integrate ad
 
 ```python
 from fastapi import FastAPI
-from freeadmin.boot import admin
+from freeadmin.core.boot import admin
 from freeadmin.hub import hub
 from my_project.admin.user_menu import ExtraUserMenuRegistrar
 

--- a/docs/admin/widgets.md
+++ b/docs/admin/widgets.md
@@ -128,7 +128,7 @@ See [contrib/admin/widgets/registry.py](../../contrib/admin/widgets/registry.py)
 ```
 
 ```python
-from freeadmin.core.models import ModelAdmin
+from freeadmin.core.interface.models import ModelAdmin
 from freeadmin.widgets import ChoicesWidget
 
 
@@ -144,7 +144,7 @@ class PostAdmin(ModelAdmin):
 - **Main options:** `options` forwarded to [JsBarcode](https://github.com/lindell/JsBarcode#options) for customizing dimensions, font, and other styling. The barcode input is hidden by default; set `show_input` to `True` to display it.
 
 ```python
-from freeadmin.core.models import ModelAdmin
+from freeadmin.core.interface.models import ModelAdmin
 from freeadmin.widgets import BarCodeWidget
 
 
@@ -162,7 +162,7 @@ class TicketAdmin(ModelAdmin):
 - **Main options:** `format` automatically set to `"date"`, `"time"`, or `"datetime-local"` based on the field kind.
 
 ```python
-from freeadmin.core.models import ModelAdmin
+from freeadmin.core.interface.models import ModelAdmin
 from freeadmin.widgets import DateTimeWidget
 
 
@@ -251,7 +251,7 @@ events when its asset is included, so no extra template code is required.
 ```
 
 ```python
-from freeadmin.core.models import ModelAdmin
+from freeadmin.core.interface.models import ModelAdmin
 from freeadmin.widgets import Select2Widget
 
 
@@ -269,7 +269,7 @@ class PostAdmin(ModelAdmin):
 - **Main options:** `type: "string"`; `format: "text"`.
 
 ```python
-from freeadmin.core.models import ModelAdmin
+from freeadmin.core.interface.models import ModelAdmin
 from freeadmin.widgets import TextWidget
 
 
@@ -292,7 +292,7 @@ class UserAdmin(ModelAdmin):
   widget's asset bundler ensures the Ace library is loaded automatically.
 
 ```python
-from freeadmin.core.models import ModelAdmin
+from freeadmin.core.interface.models import ModelAdmin
 from freeadmin.widgets import TextAreaWidget
 
 
@@ -314,7 +314,7 @@ The widget accepts extra configuration for the embedded editor. The example belo
 demonstrates how to enable Ace highlighting and tweak editor options:
 
 ```python
-from freeadmin.core.models import ModelAdmin
+from freeadmin.core.interface.models import ModelAdmin
 from freeadmin.widgets import TextAreaWidget
 
 

--- a/docs/admin/widgets/choices.md
+++ b/docs/admin/widgets/choices.md
@@ -22,9 +22,9 @@ The admin bundles `/static/widgets/choices.js`, which mirrors the Select2 helper
 ```python
 from fastapi import FastAPI
 from pydantic import BaseModel, Field
-from freeadmin.core.models import ModelAdmin
+from freeadmin.core.interface.models import ModelAdmin
 from freeadmin.widgets import ChoicesWidget
-from freeadmin.boot import admin
+from freeadmin.core.boot import admin
 
 
 class Post(BaseModel):

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -66,10 +66,10 @@ The core layer orchestrates discovery, routing, and permissions.
 
 Key components include:
 
-* `BootManager` (`freeadmin.boot`): initialises adapters, middleware, and FastAPI startup/shutdown hooks.
-* `AdminHub` and `AdminSite` (`freeadmin.hub`, `freeadmin.core.site`): keep registries for models, cards, views, menus, and settings pages.
-* `DiscoveryService` (`freeadmin.core.discovery`): scans declared packages for `app.py`, `admin.py`, and related modules that perform registrations.
-* `PermissionsService` and `PermissionChecker` (`freeadmin.core.services.permissions` and `freeadmin.core.permissions.checker`): enforce per-model and per-action access control.
+* `BootManager` (`freeadmin.core.boot`): initialises adapters, middleware, and FastAPI startup/shutdown hooks.
+* `AdminHub` and `AdminSite` (`freeadmin.hub`, `freeadmin.core.interface.site`): keep registries for models, cards, views, menus, and settings pages.
+* `DiscoveryService` (`freeadmin.core.interface.discovery`): scans declared packages for `app.py`, `admin.py`, and related modules that perform registrations.
+* `PermissionsService` and `PermissionChecker` (`freeadmin.core.interface.services.permissions` and `freeadmin.core.interface.permissions.checker`): enforce per-model and per-action access control.
 
 Together these services discover resources, expose HTTP routes, and wire system configuration such as settings pages and server-sent-event publishers.
 
@@ -86,7 +86,7 @@ The admin layer declares what appears in the interface and how it behaves.
 Example:
 
 ```python
-from freeadmin.core.models import ModelAdmin
+from freeadmin.core.interface.models import ModelAdmin
 from freeadmin.hub import admin_site
 from .models import Product
 

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -8,69 +8,49 @@
 
 | Путь | Назначение | Прямые зависимости первого порядка |
 | --- | --- | --- |
-| `freeadmin/application/factory.py` | Фабрика FastAPI-приложений, связывает настройки, ORM и роутеры | `freeadmin.boot.BootManager`, `freeadmin.orm.ORMConfig/ORMLifecycle`, `freeadmin.router.AdminRouter`, `freeadmin.hub.admin_site` |
-| `freeadmin/boot/manager.py` | Управляет адаптерами, регистрацией моделей и запуском хаба | Реестр адаптеров (`freeadmin.contrib.adapters`), системные настройки (`freeadmin.conf`, `freeadmin.core.settings`), посредник `AdminGuardMiddleware`, хаб `freeadmin.hub` |
-| `freeadmin/conf.py` | Хранилище конфигурации и наблюдатель за изменениями окружения | `os`, `pathlib`, синхронизация через `threading.RLock` |
-| `freeadmin/hub.py` | Центральный хаб админки: управляет сайтом, автодискавери и роутерами | Настройки (`freeadmin.conf`), `freeadmin.core.site.AdminSite`, `freeadmin.core.discovery.DiscoveryService`, `freeadmin.router.AdminRouter`, `freeadmin.boot.admin` |
-| `freeadmin/core/site.py` | Реализация админ-сайта: регистрация моделей/страниц, меню, экспорт | Сервисы ядра (`freeadmin.core.*`), адаптеры, CRUD, API карточек, поставщик шаблонов, проверки миграций |
-| `freeadmin/router/base.py` | Базовые вспомогательные классы для монтирования админ-маршрутов | `fastapi.FastAPI`, `freeadmin.core.templates.TemplateService`, `freeadmin.core.site.AdminSite` |
-| `freeadmin/router/aggregator.py` | Координатор создания и подключения админ- и публичных роутеров | `freeadmin.router.base.RouterFoundation`, `fastapi.APIRouter`, `freeadmin.core.site.AdminSite`, `freeadmin.core.templates.TemplateService` |
-| `freeadmin/provider.py` | Управление шаблонами, статикой и медиа | `fastapi`, `starlette.staticfiles.StaticFiles`, `freeadmin.conf.FreeAdminSettings`, `freeadmin.core.settings.system_config` |
-| `freeadmin/middleware.py` | Middleware охраны админки (суперпользователь, сессия) | `starlette` middleware, `freeadmin.conf`, `freeadmin.core.settings`, `freeadmin.boot.admin` |
-| `freeadmin/crud.py` | Построитель CRUD-роутов и файлового обмена | `fastapi`, `freeadmin.core` сервисы, `freeadmin.conf`, `freeadmin.core.settings`, `freeadmin.core.services` |
-| `freeadmin/api/base.py` | Обёртка системного API админки | `fastapi.APIRouter`, `freeadmin.contrib.adapters.BaseAdapter`, системные API `freeadmin.apps.system.api.views` |
-| `freeadmin/orm/config.py` | Конфигурация ORM и жизненный цикл Tortoise | `tortoise` ORM, реестр адаптеров, классификатор ошибок миграций (`freeadmin.utils.migration_errors`) |
+| `freeadmin/core/application/factory.py` | Фабрика FastAPI-приложений, связывает настройки, ORM и роутеры | `freeadmin.core.boot.BootManager`, `freeadmin.core.data.orm.ORMConfig/ORMLifecycle`, `freeadmin.core.network.router.AdminRouter`, `freeadmin.core.runtime.hub.admin_site` |
+| `freeadmin/core/boot/manager.py` | Управляет адаптерами, регистрацией моделей и запуском хаба | Реестр адаптеров (`freeadmin.contrib.adapters`), системные настройки (`freeadmin.core.configuration.conf`), посредник `freeadmin.core.runtime.middleware.AdminGuardMiddleware`, хаб `freeadmin.core.runtime.hub` |
+| `freeadmin/core/configuration/conf.py` | Хранилище конфигурации и наблюдатель за изменениями окружения | `os`, `pathlib`, синхронизация через `threading.RLock` |
+| `freeadmin/core/runtime/hub.py` | Центральный хаб админки: управляет сайтом, автодискавери и роутерами | Настройки (`freeadmin.core.configuration.conf`), `freeadmin.core.interface.site.AdminSite`, `freeadmin.core.interface.discovery.DiscoveryService`, `freeadmin.core.network.router.AdminRouter`, `freeadmin.core.boot.admin` |
+| `freeadmin/core/interface/site.py` | Реализация админ-сайта: регистрация моделей/страниц, меню, экспорт | Сервисы интерфейса (`freeadmin.core.interface.*`), адаптеры, CRUD, API карточек, поставщик шаблонов, проверки миграций |
+| `freeadmin/core/network/router/base.py` | Базовые вспомогательные классы для монтирования админ-маршрутов | `fastapi.FastAPI`, `freeadmin.core.interface.templates.TemplateService`, `freeadmin.core.interface.site.AdminSite` |
+| `freeadmin/core/network/router/aggregator.py` | Координатор создания и подключения админ- и публичных роутеров | `freeadmin.core.network.router.base.RouterFoundation`, `fastapi.APIRouter`, `freeadmin.core.interface.site.AdminSite`, `freeadmin.core.interface.templates.TemplateService` |
+| `freeadmin/core/runtime/provider.py` | Управление шаблонами, статикой и медиа | `fastapi`, `starlette.staticfiles.StaticFiles`, `freeadmin.core.configuration.conf.FreeAdminSettings`, `freeadmin.core.interface.settings.system_config` |
+| `freeadmin/core/runtime/middleware.py` | Middleware охраны админки (суперпользователь, сессия) | `starlette` middleware, `freeadmin.core.configuration.conf`, `freeadmin.core.interface.settings`, `freeadmin.core.boot.admin` |
+| `freeadmin/contrib/crud/operations.py` | Построитель CRUD-роутов и файлового обмена | `fastapi`, сервисы `freeadmin.core.interface`, `freeadmin.core.configuration.conf`, `freeadmin.core.interface.settings`, `freeadmin.core.interface.services` |
+| `freeadmin/api/base.py` | Обёртка системного API админки | `fastapi.APIRouter`, `freeadmin.contrib.adapters.BaseAdapter`, системные API `freeadmin.apps.system.api.views`, сервисы `freeadmin.core.interface` |
+| `freeadmin/core/data/orm/config.py` | Конфигурация ORM и жизненный цикл Tortoise | `tortoise` ORM, реестр адаптеров, классификатор ошибок миграций (`freeadmin.utils.migration_errors`) |
 
 ## 2. Уровни важности
 
-- **Ядро**: `freeadmin/core/`, `freeadmin/application/`, `freeadmin/boot/`, `freeadmin/hub.py`, `freeadmin/conf.py`, `freeadmin/orm/`, `freeadmin/adapters/`, `freeadmin/models/`. Эти элементы отвечают за конфигурацию, регистрацию ресурсов, связь с ORM и глобальные сервисы.
-- **Оболочки**: `freeadmin/api/`, `freeadmin/router/`, `freeadmin/crud.py`, `freeadmin/middleware.py`, `freeadmin/pages/`, `freeadmin/widgets/`, `freeadmin/templates/`, `freeadmin/static/`, `freeadmin/runner.py`, `freeadmin/cli.py`. Модули обеспечивают HTTP-интерфейсы, UI и вспомогательные сценарии.
+- **Ядро**: `freeadmin/core/` (подпакеты `application`, `boot`, `configuration`, `data`, `interface`, `network`, `runtime`), а также `freeadmin/contrib/adapters/` и вспомогательные модели. Эти элементы отвечают за конфигурацию, регистрацию ресурсов, связь с ORM и глобальные сервисы.
+- **Оболочки**: `freeadmin/api/`, совместимые фасады `freeadmin/router/`, `freeadmin/crud.py`, `freeadmin/middleware.py`, `freeadmin/pages/`, `freeadmin/widgets/`, `freeadmin/templates/`, `freeadmin/static/`, `freeadmin/runner.py`, `freeadmin/cli.py`. Модули обеспечивают HTTP-интерфейсы, UI и вспомогательные сценарии.
 - **Утилиты**: `freeadmin/utils/`, `freeadmin/schema/`, `freeadmin/tests/`, `freeadmin/provider.py`, `freeadmin/meta.py`. Служебные компоненты и расширяемые помощники.
 
-## 3. Предлагаемая структура (≤ 4 уровня вложенности)
+## 3. Структура ядра после реорганизации
 
 ### 3.1 Логика группировки
 
-1. **`core/`** — объединяет доменные сервисы админки, настройки и запуск. Содержит подпакеты `domain/` (текущее содержимое `core/`), `runtime/` (инициализация и хаб), `config/` (настройки и конфигурация), `orm/` (обёртки над ORM) и `adapters/` (интеграции с внешними источниками данных).
-2. **`shell/`** — внешний слой, взаимодействующий с FastAPI и фронтендом. Подпакеты `http/` (API, CRUD, маршрутизация, middleware), `presentation/` (страницы, шаблоны, виджеты, статика) и `operations/` (CLI, раннеры).
-3. **`support/`** — общие утилиты и схемы. Подпакеты `tooling/` (утилиты, схемы, тесты) и `integration/` (провайдеры ресурсов, дополнительные вспомогательные слои).
+* **`core/application/`** — фабрики и протоколы, которые собирают FastAPI‑приложения с подключённой админкой.
+* **`core/boot/`** — менеджер запуска, координирующий адаптеры, системные приложения и подключение middleware.
+* **`core/configuration/`** — настройки и менеджер конфигурации, наблюдающий за изменениями окружения.
+* **`core/data/`** — интеграция с ORM и вспомогательные модели данных.
+* **`core/interface/`** — админские дескрипторы, сервисы, шаблонные помощники и REST-интерфейсы верхнего уровня.
+* **`core/network/`** — роутеры и агрегаторы, отвечающие за монтирование HTTP-маршрутов админки.
+* **`core/runtime/`** — хаб, middleware, поставщик шаблонов и другой код, работающий во время исполнения.
 
-### 3.2 Итоговое дерево (предложение)
+Внешние расширения и интеграции лежат в `freeadmin/contrib/`, включая адаптеры и CRUD-утилиты. Совместимые фасады верхнего уровня (`freeadmin/application`, `freeadmin/boot` и т. д.) сохранены для плавного обновления, но перенаправляют импорты в перечисленные подпакеты.
 
-```
-freeadmin/
-    core/
-        domain/
-        runtime/
-        config/
-        orm/
-        adapters/
-    shell/
-        http/
-        presentation/
-        operations/
-    support/
-        tooling/
-        integration/
-```
+### 3.2 Совместимые фасады и основная реализация
 
-### 3.3 Таблица соответствия «исходный путь → целевой путь»
-
-| Исходный путь | Категория | Предлагаемый целевой путь | Комментарий |
-| --- | --- | --- | --- |
-| `freeadmin/application/factory.py` | Ядро | `freeadmin/core/runtime/application_factory.py` | Фабрика FastAPI становится частью запуска.
-| `freeadmin/boot/` | Ядро | `freeadmin/core/runtime/bootstrap/` | Управление адаптерами и моделью запуска переносится в runtime.
-| `freeadmin/hub.py` | Ядро | `freeadmin/core/runtime/hub.py` | Централизованный хаб соседствует с фабрикой и BootManager.
-| `freeadmin/conf.py` | Ядро | `freeadmin/core/config/settings.py` | Конфигурация переезжает в отдельный пакет настроек.
-| `freeadmin/core/` | Ядро | `freeadmin/core/domain/` | Текущее содержимое ядра оформляется как доменный подпакет.
-| `freeadmin/orm/` | Ядро | `freeadmin/core/orm/` | Конфигурация ORM входит в ядро.
-| `freeadmin/adapters/` | Ядро | `freeadmin/core/adapters/` | Регистрация и реализация адаптеров остаётся рядом с ORM.
-| `freeadmin/api/` | Оболочки | `freeadmin/shell/http/api/` | API и совместимость с видом системных эндпоинтов.
-| `freeadmin/router/` | Оболочки | `freeadmin/shell/http/router/` | Аггрегаторы и вспомогательные роутеры образуют HTTP-подслой.
-| `freeadmin/crud.py` | Оболочки | `freeadmin/shell/http/crud.py` | CRUD остаётся в HTTP-подслое.
-| `freeadmin/middleware.py` | Оболочки | `freeadmin/shell/http/middleware.py` | Middleware переносится рядом с роутерами.
-| `freeadmin/pages/`, `freeadmin/widgets/`, `freeadmin/templates/`, `freeadmin/static/` | Оболочки | `freeadmin/shell/presentation/{pages,widgets,templates,static}/` | UI-артефакты формируют презентационный слой.
-| `freeadmin/cli.py`, `freeadmin/runner.py` | Оболочки | `freeadmin/shell/operations/{cli.py,runner.py}` | Скрипты запуска и CLI собраны в одном подпакете.
-| `freeadmin/provider.py` | Утилиты | `freeadmin/support/integration/provider.py` | Поставщик шаблонов выступает вспомогательной интеграцией.
-| `freeadmin/utils/`, `freeadmin/schema/`, `freeadmin/tests/`, `freeadmin/meta.py` | Утилиты | `freeadmin/support/tooling/{utils,schema,tests,meta.py}` | Общие помощники и схемы находятся в слое поддержки.
-
+| Фасад совместимости | Основной модуль | Назначение |
+| --- | --- | --- |
+| `freeadmin/application` | `freeadmin.core.application` | Фабрики FastAPI-приложений. |
+| `freeadmin/boot` | `freeadmin.core.boot` | Менеджер запуска и адаптеры. |
+| `freeadmin/hub` | `freeadmin.core.runtime.hub` | Центральный хаб и автодискавери. |
+| `freeadmin/conf` | `freeadmin.core.configuration.conf` | Настройки и менеджер конфигурации. |
+| `freeadmin/orm` | `freeadmin.core.data.orm` | Конфигурация ORM и жизненный цикл. |
+| `freeadmin/router` | `freeadmin.core.network.router` | Агрегаторы и вспомогательные роутеры. |
+| `freeadmin/provider` | `freeadmin.core.runtime.provider` | Поставщик шаблонов и статики. |
+| `freeadmin/middleware` | `freeadmin.core.runtime.middleware` | AdminGuard и связанные middleware. |
+| `freeadmin/crud` | `freeadmin.contrib.crud.operations` | Построитель CRUD-маршрутов. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,10 +37,10 @@ Set these variables before your process starts (for example in a `.env` file, Do
 
 ## Programmatic configuration
 
-Call `freeadmin.conf.configure()` to install a custom `FreeAdminSettings` instance before the boot manager is created. This is useful when you want to load settings from another source or override a small subset of values without touching environment variables.
+Call `freeadmin.core.configuration.conf.configure()` to install a custom `FreeAdminSettings` instance before the boot manager is created. This is useful when you want to load settings from another source or override a small subset of values without touching environment variables.
 
 ```python
-from freeadmin.conf import FreeAdminSettings, configure
+from freeadmin.core.configuration.conf import FreeAdminSettings, configure
 
 settings = FreeAdminSettings(
     secret_key="super-secret",

--- a/docs/core-concepts-and-terminology.md
+++ b/docs/core-concepts-and-terminology.md
@@ -11,7 +11,7 @@ In day-to-day code you import the shared instance from `freeadmin.hub`:
 
 ```python
 from freeadmin.hub import admin_site
-from freeadmin.core.models import ModelAdmin
+from freeadmin.core.interface.models import ModelAdmin
 from .models import Product
 
 
@@ -30,7 +30,7 @@ The hub also exposes `hub.autodiscover([...])` for manual discovery, although mo
 
 ## ModelAdmin
 
-A **ModelAdmin** describes how a model is displayed and edited. Subclasses inherit from `freeadmin.core.models.ModelAdmin` and define declarative attributes:
+A **ModelAdmin** describes how a model is displayed and edited. Subclasses inherit from `freeadmin.core.interface.models.ModelAdmin` and define declarative attributes:
 
 * `list_display`, `search_fields`, and `ordering` control list views.
 * `fields`, `readonly_fields`, and `widgets_overrides` customise the edit form.
@@ -41,7 +41,7 @@ Model admins never execute ORM operations directly. Instead they delegate persis
 
 ## InlineModelAdmin
 
-`InlineModelAdmin` classes describe related objects that appear on a parent form. They inherit from `freeadmin.core.inline.InlineModelAdmin` and define:
+`InlineModelAdmin` classes describe related objects that appear on a parent form. They inherit from `freeadmin.core.interface.inline.InlineModelAdmin` and define:
 
 * `model`: the related model class handled by the inline.
 * `parent_fk_name`: the foreign key on the inline that points to the parent object.
@@ -65,7 +65,7 @@ You can implement a custom adapter by subclassing `BaseAdapter` and registering 
 
 ## BootManager and FastAPI integration
 
-`BootManager` (`freeadmin.boot`) is the entry point used by FastAPI applications. It performs three tasks:
+`BootManager` (`freeadmin.core.boot`) is the entry point used by FastAPI applications. It performs three tasks:
 
 1. Loads the configured adapter and any bundled models.
 2. Adds middleware such as the admin guard and session management.
@@ -75,7 +75,7 @@ Typical usage:
 
 ```python
 from fastapi import FastAPI
-from freeadmin.boot import BootManager
+from freeadmin.core.boot import BootManager
 
 
 app = FastAPI()
@@ -113,14 +113,14 @@ When the FastAPI app starts, publishers registered on the card manager begin bro
 
 ### Publishers
 
-Cards stream live data through subclasses of `freeadmin.core.sse.publisher.PublisherService`. A publisher attaches to a card key
+Cards stream live data through subclasses of `freeadmin.core.interface.sse.publisher.PublisherService`. A publisher attaches to a card key
 , fetches fresh state, and calls `publish()` whenever a new payload is available.
 
 ```python
 import asyncio
 from collections.abc import Awaitable, Callable
 
-from freeadmin.core.sse.publisher import PublisherService
+from freeadmin.core.interface.sse.publisher import PublisherService
 from freeadmin.hub import admin_site
 
 
@@ -176,10 +176,10 @@ The returned dictionary feeds the Jinja2 template responsible for rendering the 
 
 ## Actions
 
-Actions are operations that run on selected rows from the changelist. They inherit from `freeadmin.core.actions.base.BaseAction` (or one of the bundled subclasses) and implement an async `run()` method.
+Actions are operations that run on selected rows from the changelist. They inherit from `freeadmin.core.interface.actions.BaseAction` (or one of the bundled subclasses) and implement an async `run()` method.
 
 ```python
-from freeadmin.core.actions import BaseAction, ActionResult
+from freeadmin.core.interface.actions import BaseAction, ActionResult
 
 
 class MarkFeaturedAction(BaseAction):
@@ -203,7 +203,7 @@ Widgets are frontend components referenced from `ModelAdmin.widgets_overrides` o
 
 ## Settings
 
-Global configuration lives inside `freeadmin.conf.FreeAdminSettings`. Instances are normally created with `FreeAdminSettings.from_env()`, which reads environment variables prefixed with `FA_`.
+Global configuration lives inside `freeadmin.core.configuration.conf.FreeAdminSettings`. Instances are normally created with `FreeAdminSettings.from_env()`, which reads environment variables prefixed with `FA_`.
 
 Important attributes include:
 
@@ -212,7 +212,7 @@ Important attributes include:
 * `event_cache_path`: storage location for card payload caching.
 * `brand_icon` and `admin_site_title`: values shown in the UI.
 
-To override defaults in code, call `freeadmin.conf.configure(settings_instance)` before initialising the boot manager.
+To override defaults in code, call `freeadmin.core.configuration.conf.configure(settings_instance)` before initialising the boot manager.
 
 
 ## Key takeaway

--- a/docs/first-run-example.md
+++ b/docs/first-run-example.md
@@ -25,7 +25,7 @@ app = application.build()
   `describe()` helper returns a concise summary that is useful for debugging
   configuration during development.
 * `ExampleORMConfig` (`example/config/orm.py`) exports a ready-to-use
-  `ORMConfig` instance produced by :meth:`freeadmin.orm.ORMConfig.build`. The
+  `ORMConfig` instance produced by :meth:`freeadmin.core.data.orm.ORMConfig.build`. The
   declarative mapping lists project models alongside the admin/system modules
   that ship with the FreeAdmin Tortoise adapter. The helper still exposes
   `describe()` and `create_lifecycle()` methods which keeps lifecycle
@@ -56,7 +56,7 @@ app = application.build()
   ```python
   from copy import deepcopy
 
-  from freeadmin.orm import ORMConfig
+  from freeadmin.core.data.orm import ORMConfig
   from example.config.orm import DB_ADAPTER, ORM_CONFIG
 
 

--- a/docs/installation-and-cli.md
+++ b/docs/installation-and-cli.md
@@ -108,7 +108,7 @@ from typing import Any, Dict
 from freeadmin.contrib.adapters.tortoise.adapter import (
     Adapter as TortoiseAdapter,
 )
-from freeadmin.orm import ORMConfig
+from freeadmin.core.data.orm import ORMConfig
 
 DB_ADAPTER = "tortoise"
 APPLICATION_MODEL_MODULES: tuple[str, ...] = (
@@ -184,7 +184,7 @@ class Post(Model):
 
 ```python
 # apps/blog/admin.py
-from freeadmin.core.models import ModelAdmin
+from freeadmin.core.interface.models import ModelAdmin
 from freeadmin.hub import admin_site
 
 from .models import Post
@@ -200,7 +200,7 @@ class PostAdmin(ModelAdmin):
 admin_site.register(app="blog", model=Post, admin_cls=PostAdmin)
 ```
 
-If you need to run startup logic (for example to register cards or background publishers) create `apps/blog/app.py` and expose a `default` instance of `freeadmin.core.app.AppConfig`.
+If you need to run startup logic (for example to register cards or background publishers) create `apps/blog/app.py` and expose a `default` instance of `freeadmin.core.interface.app.AppConfig`.
 
 
 ## Step 8. Review the generated bootstrap
@@ -214,8 +214,8 @@ from typing import List
 
 from fastapi import FastAPI
 
-from freeadmin.boot import BootManager
-from freeadmin.orm import ORMConfig
+from freeadmin.core.boot import BootManager
+from freeadmin.core.data.orm import ORMConfig
 
 from .orm import ORM
 from .settings import ProjectSettings
@@ -272,7 +272,7 @@ The default discovery packages (`apps` and `pages`) match the directories create
 from fastapi import APIRouter
 
 from freeadmin.hub import admin_site
-from freeadmin.router import RouterAggregator
+from freeadmin.core.network.router import RouterAggregator
 
 
 class ProjectRouterAggregator(RouterAggregator):
@@ -351,7 +351,7 @@ Visit `http://127.0.0.1:8000/admin` (or the prefix you configured) and sign in w
 * **CLI cannot find `apps/`:** run the command from the project root where the scaffold created the folder.
 * **Models not discovered:** ensure the module path (e.g. `apps.blog.models`) is listed in `modules["models"]` when initialising Tortoise.
 * **`create-superuser` fails because tables are missing:** run your migrations or execute `Tortoise.generate_schemas()` after initialising the ORM so the auth tables exist.
-* **Missing static assets:** verify that `freeadmin.boot.BootManager.init()` has been called and that your ASGI server can serve the mounted static route.
+* **Missing static assets:** verify that `freeadmin.core.boot.BootManager.init()` has been called and that your ASGI server can serve the mounted static route.
 * **Session errors:** set `FA_SESSION_SECRET` to a stable value in production so session cookies remain valid across restarts.
 
 With these steps you now have a working FreeAdmin installation backed by FastAPI and Tortoise ORM. Continue exploring the other documentation chapters for more detail on cards, permissions, and custom views.

--- a/docs/models-and-admin-models.md
+++ b/docs/models-and-admin-models.md
@@ -14,7 +14,7 @@ FreeAdmin keeps a clean separation between two layers:
 
 Because the admin layer is thin, you can bring your own asynchronous ORM. The
 examples below use Tortoise ORM, but the APIs highlighted here mirror the
-adapter contracts implemented in `freeadmin.core.base.BaseModelAdmin`.
+adapter contracts implemented in `freeadmin.core.interface.base.BaseModelAdmin`.
 
 
 ## Defining an ORM model
@@ -58,7 +58,7 @@ to your database.
 
 ```python
 # apps/catalog/admin.py
-from freeadmin.core.models import ModelAdmin
+from freeadmin.core.interface.models import ModelAdmin
 from freeadmin.hub import admin_site
 
 from .models import Product
@@ -142,12 +142,12 @@ finer details before overriding them.
 ## Inline editors with `InlineModelAdmin`
 
 Inline descriptors let users edit related rows without leaving the parent form.
-Create a subclass of `freeadmin.core.inline.InlineModelAdmin`, set its `model`
+Create a subclass of `freeadmin.core.interface.inline.InlineModelAdmin`, set its `model`
 and tell FreeAdmin which foreign key links it to the parent via
 `parent_fk_name`.
 
 ```python
-from freeadmin.core.inline import InlineModelAdmin
+from freeadmin.core.interface.inline import InlineModelAdmin
 
 from .models import Product, ProductImage
 
@@ -174,13 +174,13 @@ and `BaseModelAdmin.update`, so inline POST/DELETE requests remain minimal.
 
 ## Bulk actions
 
-Actions are class-based and inherit from `freeadmin.core.actions.BaseAction`.
+Actions are class-based and inherit from `freeadmin.core.interface.actions.BaseAction`.
 They receive a queryset (or iterable compatible with your adapter), a params
 dictionary, and the current user. Returning an `ActionResult` communicates the
 outcome back to the UI.
 
 ```python
-from freeadmin.core.actions import ActionResult, ActionSpec, BaseAction
+from freeadmin.core.interface.actions import ActionResult, ActionSpec, BaseAction
 
 
 class MarkUnavailableAction(BaseAction):
@@ -307,8 +307,8 @@ class Product(Model):
 **admin.py**
 
 ```python
-from freeadmin.core.inline import InlineModelAdmin
-from freeadmin.core.models import ModelAdmin
+from freeadmin.core.interface.inline import InlineModelAdmin
+from freeadmin.core.interface.models import ModelAdmin
 from freeadmin.hub import admin_site
 
 from .models import Category, Product
@@ -344,7 +344,7 @@ admin_site.register(app="catalog", model=Product, admin_cls=ProductAdmin)
 **app.py**
 
 ```python
-from freeadmin.core.app import AppConfig
+from freeadmin.core.interface.app import AppConfig
 
 
 class CatalogConfig(AppConfig):

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -43,8 +43,8 @@ from typing import List
 
 from fastapi import FastAPI
 
-from freeadmin.boot import BootManager
-from freeadmin.orm import ORMConfig
+from freeadmin.core.boot import BootManager
+from freeadmin.core.data.orm import ORMConfig
 
 from config.orm import ORM
 from config.settings import ProjectSettings
@@ -108,7 +108,7 @@ from typing import Any
 
 from fastapi import Request
 
-from freeadmin.core.services.auth import AdminUserDTO
+from freeadmin.core.interface.services.auth import AdminUserDTO
 from freeadmin.hub import admin_site
 
 
@@ -123,10 +123,10 @@ async def sales_report(request: Request, user: AdminUserDTO) -> dict[str, Any]:
     }
 ```
 
-`AppConfig` (from `freeadmin.core.app`) lets you run code during discovery or startup. Example:
+`AppConfig` (from `freeadmin.core.interface.app`) lets you run code during discovery or startup. Example:
 
 ```python
-from freeadmin.core.app import AppConfig
+from freeadmin.core.interface.app import AppConfig
 from freeadmin.hub import admin_site
 
 from .admin import PostAdmin

--- a/docs/what-is-freeadmin.md
+++ b/docs/what-is-freeadmin.md
@@ -36,8 +36,8 @@ This modular approach lets you start with a minimal project and grow into comple
 ```python
 from fastapi import FastAPI
 
-from freeadmin.boot import BootManager
-from freeadmin.core.models import ModelAdmin
+from freeadmin.core.boot import BootManager
+from freeadmin.core.interface.models import ModelAdmin
 from freeadmin.hub import admin_site
 
 from apps.blog.models import Post

--- a/example/apps/demo/admin.py
+++ b/example/apps/demo/admin.py
@@ -4,7 +4,7 @@ Place your admin classes for your ORM models here
 
 from __future__ import annotations
 
-from freeadmin.core.models import ModelAdmin
+from freeadmin.core.interface.models import ModelAdmin
 from freeadmin.hub import admin_site
 
 from .models import DemoNote

--- a/example/apps/demo/app.py
+++ b/example/apps/demo/app.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from freeadmin.core.app import AppConfig
+from freeadmin.core.interface.app import AppConfig
 from freeadmin.hub import admin_site
 
 from .service import TemperaturePublisher

--- a/example/apps/demo/service.py
+++ b/example/apps/demo/service.py
@@ -7,7 +7,7 @@ import asyncio
 import random
 from typing import Dict
 
-from freeadmin.core.sse.publisher import PublisherService
+from freeadmin.core.interface.sse.publisher import PublisherService
 
 
 class TemperaturePublisher(PublisherService):

--- a/example/apps/demo/views.py
+++ b/example/apps/demo/views.py
@@ -7,8 +7,8 @@ from typing import Any
 
 from fastapi import Request
 
-from freeadmin.boot import admin as boot_admin
-from freeadmin.core.services.auth import AdminUserDTO
+from freeadmin.core.boot import admin as boot_admin
+from freeadmin.core.interface.services.auth import AdminUserDTO
 from freeadmin.hub import admin_site
 
 

--- a/example/config/main.py
+++ b/example/config/main.py
@@ -11,8 +11,8 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 
-from freeadmin.application import ApplicationFactory
-from freeadmin.boot import BootManager
+from freeadmin.core.application import ApplicationFactory
+from freeadmin.core.boot import BootManager
 
 from .orm import ExampleORMConfig
 from .routers import ExampleAdminRouters

--- a/example/config/orm.py
+++ b/example/config/orm.py
@@ -17,7 +17,7 @@ from typing import Any, Dict
 from freeadmin.contrib.adapters.tortoise.adapter import (
     Adapter as TortoiseAdapter,
 )
-from freeadmin.orm import ORMConfig, ORMLifecycle
+from freeadmin.core.data.orm import ORMConfig, ORMLifecycle
 
 
 DB_ADAPTER = "tortoise"

--- a/example/config/routers.py
+++ b/example/config/routers.py
@@ -16,9 +16,9 @@ from fastapi.responses import PlainTextResponse, RedirectResponse
 
 from example.pages import public_welcome_router
 from freeadmin.api.cards import public_router as card_public_router
-from freeadmin.core.settings import SettingsKey, system_config
+from freeadmin.core.interface.settings import SettingsKey, system_config
 from freeadmin.hub import admin_site
-from freeadmin.router import RouterAggregator
+from freeadmin.core.network.router import RouterAggregator
 
 
 class ExampleRouterAggregator(RouterAggregator):

--- a/example/pages/home.py
+++ b/example/pages/home.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from fastapi import Request
 
-from freeadmin.core.services.auth import AdminUserDTO
+from freeadmin.core.interface.services.auth import AdminUserDTO
 from freeadmin.hub import admin_site
 
 


### PR DESCRIPTION
## Summary
- replace documentation references to legacy modules with the new `freeadmin.core.*` interface, configuration, and network packages, including the architecture module map
- refresh the example project to import application factories, boot manager, router aggregators, and auth helpers from the new core locations
- align the README and configuration guidance with the updated package structure so generated projects reflect the current layout

## Testing
- python - <<'PY'
from example.config.main import ExampleApplication

app = ExampleApplication().build()
print(app.title)
PY

------
https://chatgpt.com/codex/tasks/task_e_68f0142c1838833089028f19e54e7360