### PR TITLE
Restore legacy CRUD exports

### DIFF
--- a/freeadmin/crud.py
+++ b/freeadmin/crud.py
@@ -10,9 +10,35 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 
-from .contrib.crud import CrudRouterBuilder
+from .contrib.crud.operations import (
+    AsyncFileSaver as _AsyncFileSaver,
+    CrudRouterBuilder as _CrudRouterBuilder,
+    MAX_UPLOAD_SIZE as _MAX_UPLOAD_SIZE,
+    SafePathSegment as _SafePathSegment,
+)
 
-__all__ = ["CrudRouterBuilder"]
+
+class CrudCompatibilityFacade:
+    """Provide accessors for CRUD helper symbols."""
+
+    SafePathSegment = _SafePathSegment
+    AsyncFileSaver = _AsyncFileSaver
+    CrudRouterBuilder = _CrudRouterBuilder
+    MAX_UPLOAD_SIZE = _MAX_UPLOAD_SIZE
+
+
+SafePathSegment = CrudCompatibilityFacade.SafePathSegment
+AsyncFileSaver = CrudCompatibilityFacade.AsyncFileSaver
+CrudRouterBuilder = CrudCompatibilityFacade.CrudRouterBuilder
+MAX_UPLOAD_SIZE = CrudCompatibilityFacade.MAX_UPLOAD_SIZE
+
+__all__ = [
+    "CrudCompatibilityFacade",
+    "SafePathSegment",
+    "AsyncFileSaver",
+    "CrudRouterBuilder",
+    "MAX_UPLOAD_SIZE",
+]
 
 
 # The End


### PR DESCRIPTION
## Summary
- restore legacy CRUD helper exports in the compatibility shim
- provide a facade exposing all CRUD helper symbols for legacy imports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f0186b0da083308021d77dd374bee3