### PR TITLE
Fix background cleanup scheduling for import service

### DIFF
--- a/freeadmin/core/interface/services/export.py
+++ b/freeadmin/core/interface/services/export.py
@@ -611,12 +611,7 @@ class ExportService:
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
-            try:
-                loop = asyncio.get_event_loop()
-            except RuntimeError:
-                return
-            if not loop.is_running():
-                return
+            return
         loop.call_later(delay, lambda t=token: self.cleanup(t))
 
     def _restore_cache_state(self) -> None:

--- a/freeadmin/core/interface/site.py
+++ b/freeadmin/core/interface/site.py
@@ -1144,7 +1144,7 @@ class AdminSite(IconPathMixin):
                 dry = payload.get("dry", False)
                 fields = payload.get("fields") or list(admin.get_import_fields())
                 report = await import_service.run(admin, token, fields, dry=dry)
-                import_service.cleanup(token)
+                await import_service.cleanup(token)
                 return report.__dict__
 
         for entry in self.registry.iter_settings():


### PR DESCRIPTION
## Summary
- ensure the import service tracks its background cleanup task and schedules it from running loops
- await cleanup once an import run completes to avoid un-awaited coroutine warnings
- avoid deprecated event loop access when scheduling export token cleanup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f02130612083309bef3237d33302a6