### PR TITLE
Translate module map documentation to English

### DIFF
--- a/docs/module-map.md
+++ b/docs/module-map.md
@@ -1,56 +1,56 @@
-# Карта модулей FreeAdmin
+# FreeAdmin Module Map
 
-## 1. Текущее состояние модулей
+## 1. Current Module State
 
-Эти сведения отражают файловую и логическую структуру каталога `freeadmin/` в текущем состоянии репозитория. Основное внимание уделено узлам, участвующим в инициализации административного ядра, интеграции с FastAPI и обслуживании пользовательского интерфейса.
+This information reflects the file and logical structure of the `freeadmin/` directory in the repository's current state. The focus is on nodes that participate in initializing the administrative core, integrating with FastAPI, and serving the user interface.
 
-### 1.1 Ключевые модули и прямые зависимости
+### 1.1 Key Modules and Direct Dependencies
 
-| Путь | Назначение | Прямые зависимости первого порядка |
+| Path | Purpose | First-order Direct Dependencies |
 | --- | --- | --- |
-| `freeadmin/core/application/factory.py` | Фабрика FastAPI-приложений, связывает настройки, ORM и роутеры | `freeadmin.core.boot.BootManager`, `freeadmin.core.data.orm.ORMConfig/ORMLifecycle`, `freeadmin.core.network.router.AdminRouter`, `freeadmin.core.runtime.hub.admin_site` |
-| `freeadmin/core/boot/manager.py` | Управляет адаптерами, регистрацией моделей и запуском хаба | Реестр адаптеров (`freeadmin.contrib.adapters`), системные настройки (`freeadmin.core.configuration.conf`), посредник `freeadmin.core.runtime.middleware.AdminGuardMiddleware`, хаб `freeadmin.core.runtime.hub` |
-| `freeadmin/core/configuration/conf.py` | Хранилище конфигурации и наблюдатель за изменениями окружения | `os`, `pathlib`, синхронизация через `threading.RLock` |
-| `freeadmin/core/runtime/hub.py` | Центральный хаб админки: управляет сайтом, автодискавери и роутерами | Настройки (`freeadmin.core.configuration.conf`), `freeadmin.core.interface.site.AdminSite`, `freeadmin.core.interface.discovery.DiscoveryService`, `freeadmin.core.network.router.AdminRouter`, `freeadmin.core.boot.admin` |
-| `freeadmin/core/interface/site.py` | Реализация админ-сайта: регистрация моделей/страниц, меню, экспорт | Сервисы интерфейса (`freeadmin.core.interface.*`), адаптеры, CRUD, API карточек, поставщик шаблонов, проверки миграций |
-| `freeadmin/core/network/router/base.py` | Базовые вспомогательные классы для монтирования админ-маршрутов | `fastapi.FastAPI`, `freeadmin.core.interface.templates.TemplateService`, `freeadmin.core.interface.site.AdminSite` |
-| `freeadmin/core/network/router/aggregator.py` | Координатор создания и подключения админ- и публичных роутеров | `freeadmin.core.network.router.base.RouterFoundation`, `fastapi.APIRouter`, `freeadmin.core.interface.site.AdminSite`, `freeadmin.core.interface.templates.TemplateService` |
-| `freeadmin/core/runtime/provider.py` | Управление шаблонами, статикой и медиа | `fastapi`, `starlette.staticfiles.StaticFiles`, `freeadmin.core.configuration.conf.FreeAdminSettings`, `freeadmin.core.interface.settings.system_config` |
-| `freeadmin/core/runtime/middleware.py` | Middleware охраны админки (суперпользователь, сессия) | `starlette` middleware, `freeadmin.core.configuration.conf`, `freeadmin.core.interface.settings`, `freeadmin.core.boot.admin` |
-| `freeadmin/contrib/crud/operations.py` | Построитель CRUD-роутов и файлового обмена | `fastapi`, сервисы `freeadmin.core.interface`, `freeadmin.core.configuration.conf`, `freeadmin.core.interface.settings`, `freeadmin.core.interface.services` |
-| `freeadmin/contrib/api/cards.py` | SSE и REST API карточек | `fastapi.APIRouter`, `freeadmin.core.interface.site.AdminSite`, сервисы `freeadmin.core.interface` |
-| `freeadmin/core/data/orm/config.py` | Конфигурация ORM и жизненный цикл Tortoise | `tortoise` ORM, реестр адаптеров, классификатор ошибок миграций (`freeadmin.utils.migration_errors`) |
+| `freeadmin/core/application/factory.py` | FastAPI application factory that wires settings, the ORM, and routers together | `freeadmin.core.boot.BootManager`, `freeadmin.core.data.orm.ORMConfig/ORMLifecycle`, `freeadmin.core.network.router.AdminRouter`, `freeadmin.core.runtime.hub.admin_site` |
+| `freeadmin/core/boot/manager.py` | Manages adapters, model registration, and hub startup | Adapter registry (`freeadmin.contrib.adapters`), system settings (`freeadmin.core.configuration.conf`), middleware `freeadmin.core.runtime.middleware.AdminGuardMiddleware`, hub `freeadmin.core.runtime.hub` |
+| `freeadmin/core/configuration/conf.py` | Configuration store and environment change observer | `os`, `pathlib`, synchronization via `threading.RLock` |
+| `freeadmin/core/runtime/hub.py` | Central admin hub that manages the site, autodiscovery, and routers | Settings (`freeadmin.core.configuration.conf`), `freeadmin.core.interface.site.AdminSite`, `freeadmin.core.interface.discovery.DiscoveryService`, `freeadmin.core.network.router.AdminRouter`, `freeadmin.core.boot.admin` |
+| `freeadmin/core/interface/site.py` | Admin site implementation: registers models/pages, menus, export | Interface services (`freeadmin.core.interface.*`), adapters, CRUD, card API, template provider, migration checks |
+| `freeadmin/core/network/router/base.py` | Base helpers for mounting admin routes | `fastapi.FastAPI`, `freeadmin.core.interface.templates.TemplateService`, `freeadmin.core.interface.site.AdminSite` |
+| `freeadmin/core/network/router/aggregator.py` | Coordinates creation and attachment of admin and public routers | `freeadmin.core.network.router.base.RouterFoundation`, `fastapi.APIRouter`, `freeadmin.core.interface.site.AdminSite`, `freeadmin.core.interface.templates.TemplateService` |
+| `freeadmin/core/runtime/provider.py` | Manages templates, static files, and media | `fastapi`, `starlette.staticfiles.StaticFiles`, `freeadmin.core.configuration.conf.FreeAdminSettings`, `freeadmin.core.interface.settings.system_config` |
+| `freeadmin/core/runtime/middleware.py` | Admin guard middleware (superuser, session) | `starlette` middleware, `freeadmin.core.configuration.conf`, `freeadmin.core.interface.settings`, `freeadmin.core.boot.admin` |
+| `freeadmin/contrib/crud/operations.py` | Builds CRUD routes and file exchange | `fastapi`, `freeadmin.core.interface` services, `freeadmin.core.configuration.conf`, `freeadmin.core.interface.settings`, `freeadmin.core.interface.services` |
+| `freeadmin/contrib/api/cards.py` | SSE and REST API for cards | `fastapi.APIRouter`, `freeadmin.core.interface.site.AdminSite`, `freeadmin.core.interface` services |
+| `freeadmin/core/data/orm/config.py` | ORM configuration and Tortoise lifecycle | `tortoise` ORM, adapter registry, migration error classifier (`freeadmin.utils.migration_errors`) |
 
-## 2. Уровни важности
+## 2. Importance Levels
 
-- **Ядро**: `freeadmin/core/` (подпакеты `application`, `boot`, `configuration`, `data`, `interface`, `network`, `runtime`), а также `freeadmin/contrib/adapters/` и вспомогательные модели. Эти элементы отвечают за конфигурацию, регистрацию ресурсов, связь с ORM и глобальные сервисы.
-- **Оболочки**: совместимые фасады `freeadmin/router/`, `freeadmin/crud.py`, `freeadmin/middleware.py`, `freeadmin/pages/`, `freeadmin/widgets/`, `freeadmin/templates/`, `freeadmin/static/`, `freeadmin/runner.py`, `freeadmin/cli.py`. Модули обеспечивают HTTP-интерфейсы, UI и вспомогательные сценарии.
-- **Утилиты**: `freeadmin/utils/`, `freeadmin/schema/`, `freeadmin/tests/`, `freeadmin/provider.py`, `freeadmin/meta.py`. Служебные компоненты и расширяемые помощники.
+- **Core**: `freeadmin/core/` (subpackages `application`, `boot`, `configuration`, `data`, `interface`, `network`, `runtime`), as well as `freeadmin/contrib/adapters/` and helper models. These elements handle configuration, resource registration, ORM integration, and global services.
+- **Shells**: compatibility facades `freeadmin/router/`, `freeadmin/crud.py`, `freeadmin/middleware.py`, `freeadmin/pages/`, `freeadmin/widgets/`, `freeadmin/templates/`, `freeadmin/static/`, `freeadmin/runner.py`, `freeadmin/cli.py`. The modules provide HTTP interfaces, the UI, and auxiliary scripts.
+- **Utilities**: `freeadmin/utils/`, `freeadmin/schema/`, `freeadmin/tests/`, `freeadmin/provider.py`, `freeadmin/meta.py`. Service components and extensible helpers.
 
-## 3. Структура ядра
+## 3. Core Structure
 
-### 3.1 Логика группировки
+### 3.1 Grouping Logic
 
-* **`core/application/`** — фабрики и протоколы, которые собирают FastAPI‑приложения с подключённой админкой.
-* **`core/boot/`** — менеджер запуска, координирующий адаптеры, системные приложения и подключение middleware.
-* **`core/configuration/`** — настройки и менеджер конфигурации, наблюдающий за изменениями окружения.
-* **`core/data/`** — интеграция с ORM и вспомогательные модели данных.
-* **`core/interface/`** — админские дескрипторы, сервисы, шаблонные помощники и REST-интерфейсы верхнего уровня.
-* **`core/network/`** — роутеры и агрегаторы, отвечающие за монтирование HTTP-маршрутов админки.
-* **`core/runtime/`** — хаб, middleware, поставщик шаблонов и другой код, работающий во время исполнения.
+* **`core/application/`** — factories and protocols that assemble FastAPI applications with the admin attached.
+* **`core/boot/`** — startup manager that coordinates adapters, system apps, and middleware wiring.
+* **`core/configuration/`** — settings and configuration manager that watches environment changes.
+* **`core/data/`** — ORM integration and supporting data models.
+* **`core/interface/`** — admin descriptors, services, template helpers, and top-level REST interfaces.
+* **`core/network/`** — routers and aggregators that mount admin HTTP routes.
+* **`core/runtime/`** — hub, middleware, template provider, and other runtime code.
 
-Внешние расширения и интеграции лежат в `freeadmin/contrib/`, включая адаптеры и CRUD-утилиты. В актуальной структуре верхнеуровневые фасады удалены: проекты подключают компоненты напрямую из подпакетов `core/` и `contrib/`.
+External extensions and integrations live in `freeadmin/contrib/`, including adapters and CRUD utilities. In the current structure, high-level facades were removed: projects plug components directly from the `core/` and `contrib/` subpackages.
 
-### 3.2 Основные публичные модули
+### 3.2 Main Public Modules
 
-| Путь | Назначение |
+| Path | Purpose |
 | --- | --- |
-| `freeadmin/core/application` | Фабрики FastAPI-приложений. |
-| `freeadmin/core/boot` | Менеджер запуска и адаптеры. |
-| `freeadmin/core/runtime/hub.py` | Центральный хаб и автодискавери. |
-| `freeadmin/core/configuration/conf.py` | Настройки и менеджер конфигурации. |
-| `freeadmin/core/data/orm` | Конфигурация ORM и жизненный цикл. |
-| `freeadmin/core/network/router` | Агрегаторы и вспомогательные роутеры. |
-| `freeadmin/core/runtime/provider.py` | Поставщик шаблонов и статики. |
-| `freeadmin/core/runtime/middleware.py` | AdminGuard и связанные middleware. |
-| `freeadmin/contrib/crud/operations.py` | Построитель CRUD-маршрутов. |
+| `freeadmin/core/application` | FastAPI application factories. |
+| `freeadmin/core/boot` | Startup manager and adapters. |
+| `freeadmin/core/runtime/hub.py` | Central hub and autodiscovery. |
+| `freeadmin/core/configuration/conf.py` | Settings and configuration manager. |
+| `freeadmin/core/data/orm` | ORM configuration and lifecycle. |
+| `freeadmin/core/network/router` | Aggregators and helper routers. |
+| `freeadmin/core/runtime/provider.py` | Template and static provider. |
+| `freeadmin/core/runtime/middleware.py` | AdminGuard and related middleware. |
+| `freeadmin/contrib/crud/operations.py` | CRUD route builder. |


### PR DESCRIPTION
## Summary
- translate the module map documentation into English while preserving its tables and structure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f0b80cf5b08330a9db11892906e53b