### PR TITLE
Add migration guard redirect and notice page when schema missing

### DIFF
--- a/freeadmin/core/data/orm/config.py
+++ b/freeadmin/core/data/orm/config.py
@@ -99,6 +99,17 @@ class ORMLifecycle:
             "Failed to initialise ORM: %s. Run your migrations before starting FreeAdmin.",
             error,
         )
+        self._mark_migrations_required()
+
+    def _mark_migrations_required(self) -> None:
+        """Mark the global configuration as requiring pending migrations."""
+
+        try:
+            from ...interface.settings import system_config
+
+            system_config.flag_migrations_required()
+        except Exception:  # pragma: no cover - defensive fall-through
+            self._logger.debug("Unable to flag migration requirement", exc_info=True)
 
     def _handle_startup_warnings(
         self,

--- a/freeadmin/core/interface/settings/config.py
+++ b/freeadmin/core/interface/settings/config.py
@@ -59,6 +59,7 @@ class SystemConfig:
         """Initialize an empty in-memory cache for system settings."""
 
         self._cache: dict[str, Any] = {}
+        self._migrations_required: bool = False
 
     @property
     def adapter(self) -> Any:
@@ -83,6 +84,7 @@ class SystemConfig:
                 "Run your migrations before starting FreeAdmin.",
                 exc,
             )
+            self.flag_migrations_required()
 
     async def _seed_defaults(self) -> None:
         """Perform the default seeding workflow within a transaction."""
@@ -146,10 +148,28 @@ class SystemConfig:
                 "Run your migrations before starting FreeAdmin.",
                 exc,
             )
+            self.flag_migrations_required()
             return
 
         self._cache.clear()
         self._cache.update(new_cache)
+        self.clear_migrations_flag()
+
+    @property
+    def migrations_required(self) -> bool:
+        """Return ``True`` when database migrations are required."""
+
+        return self._migrations_required
+
+    def flag_migrations_required(self) -> None:
+        """Record that database migrations must run before admin usage."""
+
+        self._migrations_required = True
+
+    def clear_migrations_flag(self) -> None:
+        """Reset the migration requirement marker after successful reloads."""
+
+        self._migrations_required = False
 
     def get_cached(self, key: SettingsKey | str, default: Any | None = None) -> Any:
         """Return ``key`` value directly from the in-memory cache.

--- a/freeadmin/core/interface/settings/defaults.py
+++ b/freeadmin/core/interface/settings/defaults.py
@@ -57,6 +57,7 @@ DEFAULT_SETTINGS: dict[SettingsKey, tuple[object, str]] = {
     SettingsKey.LOGIN_PATH:            ("/login", "string"),
     SettingsKey.LOGOUT_PATH:           ("/logout", "string"),
     SettingsKey.SETUP_PATH:            ("/setup", "string"),
+    SettingsKey.MIGRATIONS_PATH:       ("/migration-required", "string"),
     SettingsKey.SESSION_COOKIE:       ("session", "string"),
     SettingsKey.SESSION_KEY:           ("admin_user_id", "string"),
 

--- a/freeadmin/core/interface/settings/keys.py
+++ b/freeadmin/core/interface/settings/keys.py
@@ -64,6 +64,7 @@ class SettingsKey(StrChoices):
     LOGIN_PATH            = ("LOGIN_PATH", "Login path")
     LOGOUT_PATH           = ("LOGOUT_PATH", "Logout path")
     SETUP_PATH            = ("SETUP_PATH", "Setup path")
+    MIGRATIONS_PATH       = ("MIGRATIONS_PATH", "Migration notice path")
     SESSION_COOKIE        = ("SESSION_COOKIE", "Admin session cookie name")
     SESSION_KEY           = ("SESSION_KEY", "Admin session cookie key")
 

--- a/freeadmin/core/runtime/middleware.py
+++ b/freeadmin/core/runtime/middleware.py
@@ -44,6 +44,7 @@ class AdminGuardMiddleware(BaseHTTPMiddleware):
         self._logout_path: str | None = None
         self._setup_path: str | None = None
         self._static_path: str | None = None
+        self._migrations_path: str | None = None
         self._session_key: str | None = None
         self._has_superuser: bool | None = None
         register_settings_observer(self._apply_settings)
@@ -63,6 +64,9 @@ class AdminGuardMiddleware(BaseHTTPMiddleware):
         logout_path = await system_config.get_or_default(SettingsKey.LOGOUT_PATH)
         setup_path = await system_config.get_or_default(SettingsKey.SETUP_PATH)
         static_path = await system_config.get_or_default(SettingsKey.STATIC_PATH)
+        migrations_path = await system_config.get_or_default(
+            SettingsKey.MIGRATIONS_PATH
+        )
         session_key = await system_config.get_or_default(SettingsKey.SESSION_KEY)
 
         # Persist the most recently observed values for debugging and tests.
@@ -70,6 +74,7 @@ class AdminGuardMiddleware(BaseHTTPMiddleware):
         self._logout_path = logout_path
         self._setup_path = setup_path
         self._static_path = static_path
+        self._migrations_path = migrations_path
         self._session_key = session_key
 
         if (
@@ -77,8 +82,14 @@ class AdminGuardMiddleware(BaseHTTPMiddleware):
             or rel.startswith(logout_path)
             or rel.startswith(setup_path)
             or rel.startswith(static_path)
+            or rel.startswith(migrations_path)
         ):
             return await call_next(request)
+
+        if system_config.migrations_required:
+            return RedirectResponse(
+                f"{self.prefix}{migrations_path}", status_code=307
+            )
 
         if self._has_superuser is not True:
             qs = boot_admin.adapter.filter(

--- a/freeadmin/core/runtime/middleware.py
+++ b/freeadmin/core/runtime/middleware.py
@@ -77,6 +77,13 @@ class AdminGuardMiddleware(BaseHTTPMiddleware):
         self._migrations_path = migrations_path
         self._session_key = session_key
 
+        if system_config.migrations_required and not (
+            rel.startswith(migrations_path) or rel.startswith(static_path)
+        ):
+            return RedirectResponse(
+                f"{self.prefix}{migrations_path}", status_code=307
+            )
+
         if (
             rel.startswith(login_path)
             or rel.startswith(logout_path)
@@ -85,11 +92,6 @@ class AdminGuardMiddleware(BaseHTTPMiddleware):
             or rel.startswith(migrations_path)
         ):
             return await call_next(request)
-
-        if system_config.migrations_required:
-            return RedirectResponse(
-                f"{self.prefix}{migrations_path}", status_code=307
-            )
 
         if self._has_superuser is not True:
             qs = boot_admin.adapter.filter(

--- a/freeadmin/templates/pages/migrations_required.html
+++ b/freeadmin/templates/pages/migrations_required.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block content %}
+  <div class="col-md-6 mx-auto py-5 text-center">
+    <h2 class="mb-3">Migrations required</h2>
+    <p class="lead">{{ migration_message }}</p>
+    <p class="text-muted">Apply your database migrations and reload this page once completed.</p>
+  </div>
+{% endblock %}
+
+<!-- # The End -->

--- a/tests/test_admin_guard_middleware.py
+++ b/tests/test_admin_guard_middleware.py
@@ -229,6 +229,49 @@ class TestAdminGuardMiddlewareFallback:
 
         system_config.clear_migrations_flag()
 
+    @pytest.mark.asyncio
+    async def test_login_redirects_to_migration_notice_when_flagged(self) -> None:
+        """Redirect login requests to migrations notice when migrations are pending."""
+
+        async def _app(scope, receive, send) -> None:  # pragma: no cover - stub
+            """Provide a placeholder ASGI application for the middleware stack."""
+
+            return None
+
+        middleware = AdminGuardMiddleware(_app)
+        system_config.flag_migrations_required()
+
+        scope = {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "GET",
+            "path": "/admin/login",
+            "root_path": "",
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "headers": [],
+            "query_string": b"",
+        }
+        scope["session"] = {}
+
+        async def _receive() -> dict[str, Any]:
+            """Provide an empty HTTP request body for the ASGI scope."""
+
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        request = Request(scope, receive=_receive)
+
+        async def _call_next(_: Request) -> Response:
+            """Return a no-op response when middleware allows continuation."""
+
+            return Response("ok")
+
+        response = await middleware.dispatch(request, _call_next)
+        assert response.status_code == 307
+        assert response.headers.get("location") == "/admin/migration-required"
+
+        system_config.clear_migrations_flag()
+
 
 # The End
 

--- a/tests/test_admin_guard_middleware.py
+++ b/tests/test_admin_guard_middleware.py
@@ -186,6 +186,49 @@ class TestAdminGuardMiddlewareFallback:
 
         system_config._cache.clear()  # type: ignore[attr-defined]
 
+    @pytest.mark.asyncio
+    async def test_redirects_to_migration_notice_when_flagged(self) -> None:
+        """Redirect to the migration notice page when migrations are pending."""
+
+        async def _app(scope, receive, send) -> None:  # pragma: no cover - stub
+            """Provide a placeholder ASGI application for the middleware stack."""
+
+            return None
+
+        middleware = AdminGuardMiddleware(_app)
+        system_config.flag_migrations_required()
+
+        scope = {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "GET",
+            "path": "/admin/",
+            "root_path": "",
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "headers": [],
+            "query_string": b"",
+        }
+        scope["session"] = {}
+
+        async def _receive() -> dict[str, Any]:
+            """Provide an empty HTTP request body for the ASGI scope."""
+
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        request = Request(scope, receive=_receive)
+
+        async def _call_next(_: Request) -> Response:
+            """Return a no-op response when middleware allows continuation."""
+
+            return Response("ok")
+
+        response = await middleware.dispatch(request, _call_next)
+        assert response.status_code == 307
+        assert response.headers.get("location") == "/admin/migration-required"
+
+        system_config.clear_migrations_flag()
+
 
 # The End
 

--- a/tests/test_admin_migration_notice.py
+++ b/tests/test_admin_migration_notice.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""admin migration notice
+
+Validate rendering of the migration-required admin page."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from freeadmin.core.boot import admin as boot_admin
+from freeadmin.core.interface.site import AdminSite
+from freeadmin.core.network.router.aggregator import RouterAggregator
+from tests.conftest import admin_state
+
+
+def test_migration_notice_route_renders() -> None:
+    """Render the migration notice page with helpful instructions."""
+
+    admin_state.reset()
+    site = AdminSite(boot_admin.adapter, title="Migration Check")
+    aggregator = RouterAggregator(site=site)
+    app = FastAPI()
+    aggregator.mount(app)
+
+    with TestClient(app) as client:
+        response = client.get("/admin/migration-required")
+    assert response.status_code == 503
+    assert "Run your migrations before starting FreeAdmin." in response.text
+
+    admin_state.reset()
+
+
+# The End


### PR DESCRIPTION
## Summary
- track missing migrations via SystemConfig and expose a configurable migration notice path
- redirect admin requests to a migration notice page and render a dedicated template when schema setup is incomplete
- cover the new middleware behaviour and migration notice rendering with automated tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f107ec0c948330a2b6fe5e2770375d