### PR TITLE
Allow configuring favicon asset

### DIFF
--- a/freeadmin/core/configuration/conf.py
+++ b/freeadmin/core/configuration/conf.py
@@ -34,7 +34,8 @@ class FreeAdminSettings:
     action_batch_size: int = 50
     card_events_token_ttl: int = 3600
     admin_site_title: str = "FreeAdmin"
-    brand_icon: str = ""
+    brand_icon: str = "freeadmin/static/images/icon-36x36.png"
+    favicon_path: str = "freeadmin/static/images/favicon.ico"
     database_url: str | None = None
     static_url_segment: str = "/static"
     static_route_name: str = "admin-static"
@@ -102,7 +103,8 @@ class FreeAdminSettings:
         action_batch_size = cls._to_int(data.get("ACTION_BATCH_SIZE"), default=50)
         card_ttl = cls._to_int(data.get("CARD_EVENTS_TOKEN_TTL"), default=3600)
         admin_site_title = data.get("ADMIN_SITE_TITLE") or "FreeAdmin"
-        brand_icon = data.get("BRAND_ICON") or ""
+        brand_icon = data.get("BRAND_ICON") or "freeadmin/static/images/icon-36x36.png"
+        favicon_path = data.get("FAVICON_PATH") or "freeadmin/static/images/favicon.ico"
         database_url = data.get("DATABASE_URL") or source.get("DATABASE_URL")
         static_segment = data.get("STATIC_URL_SEGMENT") or "/static"
         static_route = data.get("STATIC_ROUTE_NAME") or "admin-static"
@@ -124,6 +126,7 @@ class FreeAdminSettings:
             card_events_token_ttl=card_ttl,
             admin_site_title=admin_site_title,
             brand_icon=brand_icon,
+            favicon_path=favicon_path,
             database_url=database_url,
             static_url_segment=static_segment,
             static_route_name=static_route,

--- a/freeadmin/core/interface/settings/defaults.py
+++ b/freeadmin/core/interface/settings/defaults.py
@@ -26,7 +26,8 @@ DEFAULT_SETTINGS: dict[SettingsKey, tuple[object, str]] = {
     SettingsKey.DEFAULT_LOCALE:       ("en", "string"),
 
     # Page icons
-    SettingsKey.BRAND_ICON:            ("icon-36x36.png", "string"),
+    SettingsKey.BRAND_ICON:            ("freeadmin/static/images/icon-36x36.png", "string"),
+    SettingsKey.FAVICON_PATH:          ("freeadmin/static/images/favicon.ico", "string"),
     SettingsKey.VIEWS_PAGE_ICON:       ("bi-eye", "string"),
     SettingsKey.ORM_PAGE_ICON:         ("bi-diagram-3", "string"),
     SettingsKey.SETTINGS_PAGE_ICON:    ("bi-gear", "string"),

--- a/freeadmin/core/interface/settings/keys.py
+++ b/freeadmin/core/interface/settings/keys.py
@@ -28,6 +28,7 @@ class SettingsKey(StrChoices):
 
     # --- Page icons ---
     BRAND_ICON           = ("BRAND_ICON", "Brand icon path")
+    FAVICON_PATH         = ("FAVICON_PATH", "Favicon file path")
     VIEWS_PAGE_ICON       = ("VIEWS_PAGE_ICON", "Views icon (Bootstrap 5 class)")
     ORM_PAGE_ICON         = ("ORM_PAGE_ICON", "ORM icon (Bootstrap 5 class)")
     SETTINGS_PAGE_ICON    = ("SETTINGS_PAGE_ICON", "Settings icon (Bootstrap 5 class)")

--- a/freeadmin/templates/base.html
+++ b/freeadmin/templates/base.html
@@ -23,8 +23,9 @@
     </script>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark p-2">
       <div class="container-fluid">
+        {% set default_brand_icon = prefix ~ '/static/images/icon-36x36.png' %}
         <a class="navbar-brand d-flex align-items-center" href="{{ prefix }}/">
-          <img src="{{ brand_icon }}" alt="brand icon" class="me-2" width="36" height="36">
+          <img src="{{ brand_icon or default_brand_icon }}" alt="brand icon" class="me-2" width="36" height="36">
           {{ site_title }}
         </a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">

--- a/freeadmin/tests/test_template_provider.py
+++ b/freeadmin/tests/test_template_provider.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+"""
+tests.test_template_provider
+
+Unit tests for the TemplateProvider static asset handling.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from freeadmin.core.configuration.conf import FreeAdminSettings
+from freeadmin.core.interface.settings import SettingsKey, system_config
+from freeadmin.core.runtime.provider import TemplateProvider
+
+
+def test_mount_favicon_skips_missing_asset(monkeypatch, tmp_path) -> None:
+    """Missing favicon files should not crash mounting and emit a warning."""
+
+    warnings: list[str] = []
+
+    def capture_warning(message: str, *args: object, **kwargs: object) -> None:
+        warnings.append(message % args if args else message)
+
+    monkeypatch.setattr(
+        "freeadmin.core.runtime.provider.logger.warning",
+        capture_warning,
+    )
+
+    missing_icon = tmp_path / "missing.ico"
+
+    def fake_get_cached(key, default):
+        if key == SettingsKey.FAVICON_PATH:
+            return str(missing_icon)
+        return default
+
+    monkeypatch.setattr(system_config, "get_cached", fake_get_cached)
+
+    provider = TemplateProvider(
+        templates_dir=[tmp_path],
+        static_dir=tmp_path,
+        settings=FreeAdminSettings(),
+    )
+    app = FastAPI()
+
+    provider.mount_favicon(app)
+
+    assert all(route.path != "/favicon.ico" for route in app.router.routes)
+    assert any("missing.ico" in message for message in warnings)
+
+
+def test_mount_favicon_supports_absolute_path(monkeypatch, tmp_path) -> None:
+    """Administrators should be able to provide absolute favicon paths."""
+
+    favicon_dir = tmp_path / "media"
+    favicon_dir.mkdir()
+    favicon_file = favicon_dir / "custom.ico"
+    favicon_file.write_bytes(b"custom icon bytes")
+
+    def fake_get_cached(key, default):
+        if key == SettingsKey.FAVICON_PATH:
+            return str(favicon_file)
+        return default
+
+    monkeypatch.setattr(system_config, "get_cached", fake_get_cached)
+
+    provider = TemplateProvider(
+        templates_dir=[tmp_path],
+        static_dir=tmp_path,
+        settings=FreeAdminSettings(),
+    )
+    app = FastAPI()
+
+    provider.mount_favicon(app)
+
+    client = TestClient(app)
+    response = client.get("/favicon.ico")
+    assert response.status_code == 200
+    assert response.content == b"custom icon bytes"
+
+
+def test_mount_favicon_resolves_packaged_static(monkeypatch, tmp_path) -> None:
+    """Default packaged favicon should be resolved even with prefixed paths."""
+
+    static_dir = Path(__file__).resolve().parent.parent / "static"
+
+    def fake_get_cached(key, default):
+        if key == SettingsKey.FAVICON_PATH:
+            return "freeadmin/static/images/favicon.ico"
+        return default
+
+    monkeypatch.setattr(system_config, "get_cached", fake_get_cached)
+
+    provider = TemplateProvider(
+        templates_dir=[tmp_path],
+        static_dir=static_dir,
+        settings=FreeAdminSettings(),
+    )
+    app = FastAPI()
+
+    provider.mount_favicon(app)
+
+    client = TestClient(app)
+    response = client.get("/favicon.ico")
+    assert response.status_code == 200
+    assert len(response.content) > 0
+
+
+# The End


### PR DESCRIPTION
## Summary
- add a configurable FAVICON_PATH setting with defaults for packaged assets
- enhance TemplateProvider to resolve favicon paths safely and fall back to bundled files
- cover favicon mounting scenarios with new tests and ensure base template uses the default brand icon

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f125e1c8a48330a5c55bd06174de36