### PR TITLE
Add base template page helper for admin/public views

### DIFF
--- a/docs/first-run-example.md
+++ b/docs/first-run-example.md
@@ -159,11 +159,10 @@ this keeps experiments reproducible.
 ### Standalone welcome page
 
 `example/pages/home.py` shows how to register additional views that are not tied
-to a specific application. The `ExampleWelcomePage` class keeps its registration
-logic encapsulated so the admin welcome screen mounts itself under
-`/example/welcome` exactly once and exposes the resulting handler for reuse.
-The implementation relies on `admin_site.build_template_ctx()` to reuse
-FreeAdmin’s standard layout while injecting its own message.
+to a specific application. The `ExampleWelcomePage` class inherits from
+`BaseTemplatePage`, so it only implements `get_context()` and delegates the
+registration ceremony. Instantiating the class automatically mounts the welcome
+screen under `/example/welcome` and keeps the setup idempotent.
 
 ## Next steps
 

--- a/example/pages/home.py
+++ b/example/pages/home.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 
 from fastapi import Request
 
+from freeadmin.core.interface.pages import BaseTemplatePage
 from freeadmin.core.interface.services.auth import AdminUserDTO
 from freeadmin.core.runtime.hub import admin_site
 
 
-class ExampleWelcomePage:
+class ExampleWelcomePage(BaseTemplatePage):
     """Register a welcome page showcasing custom admin content."""
 
     path = "/example/welcome"
@@ -18,43 +19,26 @@ class ExampleWelcomePage:
     icon = "bi-stars"
 
     def __init__(self) -> None:
-        """Store helpers required for page registration."""
+        """Initialise the welcome page and register it with the admin site."""
 
-        self._site = admin_site
-        self._handler: (object | None) = None
+        super().__init__(site=admin_site)
+        self.register_admin_view()
 
-    def register(self) -> None:
-        """Attach the welcome page handler to the admin site."""
+    async def get_context(
+        self,
+        *,
+        request: Request,
+        user: AdminUserDTO | None = None,
+    ) -> dict[str, object]:
+        """Return context for the admin welcome page."""
 
-        if self._handler is not None:
-            return
-
-        @self._site.register_view(
-            path=self.path,
-            name=self.name,
-            label=self.label,
-            icon=self.icon,
-        )
-        async def welcome_page(
-            request: Request, user: AdminUserDTO
-        ) -> dict[str, object]:
-            return self._site.build_template_ctx(
-                request,
-                user,
-                page_message="Welcome to the FreeAdmin example!",
-                card_entries=[],
-            )
-
-        self._handler = welcome_page
-
-    def get_handler(self) -> object | None:
-        """Return the registered handler for the admin welcome page."""
-
-        return self._handler
+        return {
+            "page_message": "Welcome to the FreeAdmin example!",
+            "card_entries": [],
+        }
 
 
 example_welcome_page = ExampleWelcomePage()
-example_welcome_page.register()
 
 __all__ = ["ExampleWelcomePage", "example_welcome_page"]
 

--- a/example/pages/public_welcome.py
+++ b/example/pages/public_welcome.py
@@ -15,11 +15,11 @@ from pathlib import Path
 
 from fastapi import Request
 
+from freeadmin.core.interface.pages import BaseTemplatePage
 from freeadmin.core.runtime.hub import admin_site
-from freeadmin.core.interface.templates import TemplateRenderer
 
 
-class ExamplePublicWelcomeContext:
+class ExamplePublicWelcomeContext(BaseTemplatePage):
     """Register the example public welcome page with the admin site."""
 
     path = "/"
@@ -28,17 +28,16 @@ class ExamplePublicWelcomeContext:
     template_directory = Path(__file__).resolve().parent.parent / "templates"
 
     def __init__(self) -> None:
-        """Register the public welcome view when the context helper is created."""
+        """Register the public welcome view when instantiated."""
 
-        self._ensure_template_registration()
-        admin_site.register_public_view(
-            path=self.path,
-            name=self.name,
-            template=self.template,
-        )(self.render_context)
+        super().__init__(site=admin_site)
+        self.register_public_view()
 
-    async def render_context(
-        self, request: Request, user: object | None = None
+    async def get_context(
+        self,
+        *,
+        request: Request,
+        user: object | None = None,
     ) -> dict[str, object]:
         """Return template context for the welcome example page."""
 
@@ -46,12 +45,6 @@ class ExamplePublicWelcomeContext:
             "subtitle": "Rendered outside the admin",
             "user": user,
         }
-
-    def _ensure_template_registration(self) -> None:
-        """Register example templates with the shared template renderer."""
-
-        service = TemplateRenderer.get_service()
-        service.add_template_directory(self.template_directory)
 
 
 example_public_welcome_context = ExamplePublicWelcomeContext()


### PR DESCRIPTION
## Summary
- add a reusable `BaseTemplatePage` helper that integrates template services and registration utilities
- refactor the example welcome pages to extend the new base class
- document how projects can rely on the base helper when wiring custom pages

## Testing
- pytest tests/test_public_pages.py

------
https://chatgpt.com/codex/tasks/task_e_68f154e788148330adc4a95d3537ac50