### PR TITLE
Document BaseTemplatePage usage

### DIFF
--- a/docs/admin/public-pages.md
+++ b/docs/admin/public-pages.md
@@ -62,7 +62,12 @@ context. The page manager injects the request, anonymous user, and page title be
 rendering the template through :class:`PageTemplateResponder`.
 
 ``BaseTemplatePage`` registers declared template directories with the shared
-renderer, so templates become available immediately after instantiation.
+renderer, so templates become available immediately after instantiation. The
+same subclass can call :meth:`BaseTemplatePage.register_admin_view` when you
+want to expose the page to authenticated staff while keeping
+``register_public_view()`` for anonymous visitors. This allows you to share
+context-building logic, templates, or even static assets between both
+interfaces.
 
 Place a template at `example/templates/pages/welcome.html`. It can extend the
 administrative layout while remaining visually independent:

--- a/freeadmin/core/interface/pages.py
+++ b/freeadmin/core/interface/pages.py
@@ -38,7 +38,23 @@ if TYPE_CHECKING:  # pragma: no cover - typing helpers only
 
 
 class BaseTemplatePage:
-    """Provide reusable registration helpers for admin and public pages."""
+    """Provide reusable registration helpers for admin and public pages.
+
+    Subclass this helper when you need class-based pages that automatically
+    integrate with :class:`AdminSite`. Declare the route metadata (``path``,
+    ``name``, optional ``icon`` and ``label``), point ``template`` at the
+    template to render, and optionally supply ``template_directory`` so the
+    renderer can discover project-specific templates. Instantiating the
+    subclass wires the template directories into the shared
+    :class:`TemplateService` and keeps registrations idempotent.
+
+    Override :meth:`get_context` to provide extra values for the template. When
+    you call :meth:`register_admin_view` or :meth:`register_public_view`, the
+    class wraps :meth:`get_context` in an async handler compatible with
+    FastAPI's routing layer. You can still override :meth:`get_handler` (or
+    :meth:`get_public_handler`) when you need complete control over the
+    endpoint implementation.
+    """
 
     path: str
     name: str


### PR DESCRIPTION
## Summary
- expand the BaseTemplatePage class docstring with inheritance and handler guidance
- document class-based page usage in the admin pages guide, including a concrete example
- clarify how BaseTemplatePage can register both admin and public views in the public pages guide

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f1fcbadb288330a4beec579480154f