### PR TITLE
Add test covering example public menu configuration

### DIFF
--- a/tests/test_example_application.py
+++ b/tests/test_example_application.py
@@ -57,6 +57,21 @@ class TestExampleApplicationSmoke:
 
         assert has_public_welcome_route is True
 
+    def test_public_menu_entries_registered(self) -> None:
+        """Ensure the example application registers public menu entries."""
+
+        application = ExampleApplication()
+        app = application.build()
+
+        admin_site = app.state.admin_site
+        menu_items = admin_site.public_menu_builder.build_menu()
+        menu_paths = {item.path for item in menu_items}
+        menu_titles = {item.title for item in menu_items}
+
+        assert "/docs" in menu_paths
+        assert "Documentation" in menu_titles
+        assert "/login" in menu_paths
+
 
 class TestExampleApplicationStartup:
     """Ensure application configs execute startup hooks during boot."""


### PR DESCRIPTION
## Summary
- add a smoke test that checks the example application's public menu entries

## Testing
- pytest tests/test_example_application.py

------
https://chatgpt.com/codex/tasks/task_e_68f2065e2d808330be6a18c7fa718217