### PR TITLE
Document admin behaviour without migrations

### DIFF
--- a/docs/first-run-example.md
+++ b/docs/first-run-example.md
@@ -104,7 +104,14 @@ app = application.build()
 
    The admin interface will be available at `http://127.0.0.1:8000/admin` once
    the server is running. On the first visit you will be redirected to the
-   built-in setup screen where you can create the initial superuser. You can
+   built-in setup screen where you can create the initial superuser. FreeAdmin
+   starts even when your database has no migrations—the public demo endpoints
+   remain online—but opening the admin without the required schema redirects you
+   to a notice explaining how to prepare the database.
+
+   ![Missing schema notice](images/scr-3.jpg)
+
+   You can
    also create it ahead of time from the command line:
 
    ```bash

--- a/docs/installation-and-cli.md
+++ b/docs/installation-and-cli.md
@@ -345,6 +345,10 @@ uvicorn config.main:app --reload
 
 Visit `http://127.0.0.1:8000/admin` (or the prefix you configured) and sign in with the credentials created in the previous step. The default interface includes list and detail views for any registered `ModelAdmin`, plus navigation for cards and custom pages.
 
+> **Heads up:** FreeAdmin boots even when your database has no migrations. Public routes and any custom FastAPI routers remain available, but visiting the admin will redirect you to a setup notice that explains the missing schema. Use the migration or schema generation workflow for your adapter to unlock the full interface.
+
+![Missing schema notice](images/scr-3.jpg)
+
 
 ## Step 12. Troubleshooting tips
 


### PR DESCRIPTION
## Summary
- explain that FreeAdmin still boots without migrations while public routes stay available
- clarify that visiting the admin without the required schema redirects to a setup notice and add the supporting screenshot to two guides

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f21a0f83408330a25889e85094e56b