### PR TITLE
Ensure static asset URLs are scheme agnostic

### DIFF
--- a/freeadmin/templates/base.html
+++ b/freeadmin/templates/base.html
@@ -6,9 +6,17 @@
     <title>{{ site_title }} — Admin</title>
     {% set static_route = settings.static_route_name %}
     {% set home_url = prefix if prefix == '/' else prefix ~ '/' %}
+    {% set root_path = request.scope.get('root_path', '') %}
+    {% if root_path %}
+      {% set root_path = root_path.rstrip('/') %}
+    {% endif %}
+    {% macro static_href(asset_path) -%}
+      {%- set relative = request.app.url_path_for(static_route, path=asset_path) -%}
+      {%- if root_path -%}{{ root_path ~ relative }}{%- else -%}{{ relative }}{%- endif -%}
+    {%- endmacro %}
     {# Local vendor bundles served from static/vendors #}
-    <link href="{{ request.url_for(static_route, path='vendors/bootstrap/css/bootstrap.min.css') }}" rel="stylesheet">
-    <link href="{{ request.url_for(static_route, path='vendors/bootstrap-icons/font/bootstrap-icons.css') }}" rel="stylesheet">
+    <link href="{{ static_href('vendors/bootstrap/css/bootstrap.min.css') }}" rel="stylesheet">
+    <link href="{{ static_href('vendors/bootstrap-icons/font/bootstrap-icons.css') }}" rel="stylesheet">
     {% if assets and assets.css %}
       {% for href in assets.css %}
       <link rel="stylesheet" href="{{ href }}">
@@ -27,7 +35,7 @@
     {% endif %}
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark p-2">
       <div class="container-fluid">
-        {% set default_brand_icon = request.url_for(static_route, path='images/icon-36x36.png') %}
+        {% set default_brand_icon = static_href('images/icon-36x36.png') %}
         <a class="navbar-brand d-flex align-items-center" href="{{ home_url }}">
           <img src="{{ brand_icon or default_brand_icon }}" alt="brand icon" class="me-2" width="36" height="36">
           {{ site_title }}
@@ -102,14 +110,14 @@
       </div>
     </footer>
 
-    <script src="{{ request.url_for(static_route, path='vendors/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
+    <script src="{{ static_href('vendors/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
     {% if assets and assets.js %}
       {% for src in assets.js %}
       <script src="{{ src }}"></script>
       {% endfor %}
     {% endif %}
     {% block scripts %}
-      <script src="{{ request.url_for(static_route, path='sidebar.js') }}"></script>
+      <script src="{{ static_href('sidebar.js') }}"></script>
       <script>
         window.addEventListener('DOMContentLoaded', () => Sidebar.load());
       </script>

--- a/freeadmin/templates/context/form.html
+++ b/freeadmin/templates/context/form.html
@@ -31,11 +31,18 @@
   {% for src in assets.js %}
   <script src="{{ src }}"></script>
   {% endfor %}
-  <script src="{{ request.url_for(settings.static_route_name, path='admin-form.js') }}"></script>
-  <script src="{{ request.url_for(settings.static_route_name, path='vendors/json-editor/dist/jsoneditor.min.js') }}"></script>
+  {% set _root_path = request.scope.get('root_path', '') %}
+  {% if _root_path %}
+    {% set _root_path = _root_path.rstrip('/') %}
+  {% endif %}
+  {% set _admin_form_relative = request.app.url_path_for(settings.static_route_name, path='admin-form.js') %}
+  {% set _json_editor_relative = request.app.url_path_for(settings.static_route_name, path='vendors/json-editor/dist/jsoneditor.min.js') %}
+  <script src="{{ static_href('admin-form.js') if static_href is defined else (_root_path ~ _admin_form_relative if _root_path else _admin_form_relative) }}"></script>
+  <script src="{{ static_href('vendors/json-editor/dist/jsoneditor.min.js') if static_href is defined else (_root_path ~ _json_editor_relative if _root_path else _json_editor_relative) }}"></script>
   <script>
     if (window.ace?.config?.set) {
-      {% set ace_base = request.url_for(settings.static_route_name, path='vendors/ace-builds/src-noconflict') %}
+      {% set _ace_relative = request.app.url_path_for(settings.static_route_name, path='vendors/ace-builds/src-noconflict') %}
+      {% set ace_base = static_href('vendors/ace-builds/src-noconflict') if static_href is defined else (_root_path ~ _ace_relative if _root_path else _ace_relative) %}
       window.ace.config.set("basePath", "{{ ace_base }}/");
     }
   </script>

--- a/freeadmin/templates/context/list.html
+++ b/freeadmin/templates/context/list.html
@@ -89,7 +89,12 @@
 
 {% block scripts %}
   {{ super() }}
-  <script src="{{ request.url_for(settings.static_route_name, path='admin-list.js') }}"></script>
+  {% set _root_path = request.scope.get('root_path', '') %}
+  {% if _root_path %}
+    {% set _root_path = _root_path.rstrip('/') %}
+  {% endif %}
+  {% set _admin_list_relative = request.app.url_path_for(settings.static_route_name, path='admin-list.js') %}
+  <script src="{{ static_href('admin-list.js') if static_href is defined else (_root_path ~ _admin_list_relative if _root_path else _admin_list_relative) }}"></script>
   <script>
     new AdminList().load();
   </script>

--- a/freeadmin/templates/includes/filters.html
+++ b/freeadmin/templates/includes/filters.html
@@ -9,7 +9,12 @@
     </div>
   </div>
 
-<script src="{{ request.url_for(settings.static_route_name, path='filter-panel.js') }}"></script>
+{% set _root_path = request.scope.get('root_path', '') %}
+{% if _root_path %}
+  {% set _root_path = _root_path.rstrip('/') %}
+{% endif %}
+{% set _filter_panel_relative = request.app.url_path_for(settings.static_route_name, path='filter-panel.js') %}
+<script src="{{ static_href('filter-panel.js') if static_href is defined else (_root_path ~ _filter_panel_relative if _root_path else _filter_panel_relative) }}"></script>
 <script>
   window._filters = new FiltersPanel({ app: "{{ current_app }}", model: "{{ current_model }}", clearButtonId: 'clear-filters-btn' });
   </script>

--- a/tests/test_static_assets.py
+++ b/tests/test_static_assets.py
@@ -1,0 +1,63 @@
+"""static assets
+
+Validate scheme-agnostic URL handling for static assets."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from starlette.requests import Request
+
+from freeadmin.core.configuration.conf import current_settings
+from freeadmin.core.interface.base import BaseModelAdmin
+
+
+class _AdapterStub:
+    """Provide a minimal adapter stub for BaseModelAdmin instantiation."""
+
+
+class DummyModel:
+    """Represent a stand-in model for BaseModelAdmin tests."""
+
+
+class TestStaticAssetPrefixing:
+    """Ensure static asset URL generation stays scheme agnostic."""
+
+    def test_prefix_static_uses_relative_path_for_https_requests(self) -> None:
+        """Verify `_prefix_static` strips schemes even on HTTPS requests."""
+
+        settings = current_settings()
+        route_name = settings.static_route_name
+        app = FastAPI()
+
+        @app.get("/staticfiles/{path:path}", name=route_name)
+        async def static_proxy(path: str) -> dict[str, str]:  # pragma: no cover - helper route
+            """Provide a placeholder static response for URL generation."""
+
+            return {"path": path}
+
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": "GET",
+            "path": "/admin/",  # arbitrary request path
+            "raw_path": b"/admin/",
+            "scheme": "https",
+            "headers": [],
+            "query_string": b"",
+            "client": ("testclient", 443),
+            "server": ("testserver", 443),
+            "app": app,
+            "root_path": "/tenant",
+        }
+        request = Request(scope)
+        admin = BaseModelAdmin(DummyModel, _AdapterStub())
+
+        asset_url = admin._prefix_static("/static/vendors/example.js", request=request)
+
+        assert asset_url.startswith("/tenant/staticfiles/vendors/example.js")
+        assert "http://" not in asset_url
+
+
+# The End
+


### PR DESCRIPTION
## Summary
- ensure the admin interface prefixes static assets with scheme-agnostic URLs when a request context is available
- update HTML templates to rely on root-path aware relative static asset paths
- add a regression test confirming that HTTPS requests never yield absolute `http://` asset URLs

## Testing
- pytest tests/test_static_assets.py

------
https://chatgpt.com/codex/tasks/task_e_68f274cc3b208330875ef545028efb57