### PR TITLE
Remove unused TextChoices and IntegerChoices aliases

### DIFF
--- a/freeadmin/models/__init__.py
+++ b/freeadmin/models/__init__.py
@@ -10,7 +10,7 @@ Email: timurkady@yandex.com
 
 from __future__ import annotations
 
-from .choices import IntChoices, IntegerChoices, StrChoices, TextChoices  # noqa: F401
+from .choices import IntChoices, StrChoices  # noqa: F401
 from .content_type import AdminContentType  # noqa: F401
 from .groups import AdminGroup, AdminGroupPermission  # noqa: F401
 from .setting import SystemSetting  # noqa: F401

--- a/freeadmin/models/_registry.py
+++ b/freeadmin/models/_registry.py
@@ -74,8 +74,6 @@ class ModelRegistry:
         base_exports = [
             "StrChoices",
             "IntChoices",
-            "TextChoices",
-            "IntegerChoices",
             "PermAction",
             "SettingValueType",
         ]

--- a/freeadmin/models/choices.py
+++ b/freeadmin/models/choices.py
@@ -91,14 +91,5 @@ class IntChoices(ChoicesMixin, IntEnum):
     def __str__(self) -> str:
         """Return the ``value`` as string."""
         return str(self.value)
-
-
-class TextChoices(StrChoices):
-    """String-based choices for admin and ORM models."""
-
-
-class IntegerChoices(IntChoices):
-    """Integer-based choices for admin and ORM models."""
-
 # The End
 


### PR DESCRIPTION
## Summary
- remove the empty TextChoices and IntegerChoices aliases from the choices module
- stop exporting the removed aliases from the models package

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6907b1b56180833081189d335638e7b2