### PR TITLE
Fix standalone view rendering example

### DIFF
--- a/docs/admin/pages.md
+++ b/docs/admin/pages.md
@@ -60,7 +60,8 @@ existing model admins.
 
 ```python
 from fastapi import Request
-from freeadmin.core.runtime.hub import admin_site, render
+from freeadmin.core.interface.templates.rendering import render_template
+from freeadmin.core.runtime.hub import admin_site
 
 
 @admin_site.register_view(
@@ -71,7 +72,7 @@ from freeadmin.core.runtime.hub import admin_site, render
 )
 async def blog_stats_view(request: Request):
     metrics = await load_blog_metrics()
-    return render("blog/stats.html", {"metrics": metrics}, request=request)
+    return render_template("blog/stats.html", {"metrics": metrics}, request=request)
 ```
 
 > **Note:** `AdminRouter.mount()` automatically adds the admin base path as a prefix,


### PR DESCRIPTION
## Summary
- update the standalone admin view example to import the correct template helper
- call `render_template` in the documentation sample so it matches the API

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690ca62f4c0c8330879ce3aac9eb03ea