### PR TITLE
Update system model reference in install docs

### DIFF
--- a/docs/installation-and-cli.md
+++ b/docs/installation-and-cli.md
@@ -326,13 +326,16 @@ from tortoise import Tortoise
 async def prepare() -> None:
     await Tortoise.init(
         db_url="sqlite:///./db.sqlite3",
-        modules={"models": ["apps.blog.models", "freeadmin.contrib.auth.models"]},
+        modules={"models": ["apps.blog.models", "freeadmin.contrib.apps.system.models"]},
     )
     await Tortoise.generate_schemas()
 
 
 asyncio.run(prepare())
 ```
+
+`freeadmin.contrib.apps.system.models` ships with the adapter and exposes the system tables (including authentication models)
+required by the admin interface.
 
 
 ## Step 11. Run the development server


### PR DESCRIPTION
## Summary
- update the Tortoise initialisation example to reference the system models module currently shipped with the adapter
- clarify that the module provides the adapter-managed system and authentication tables required by FreeAdmin

## Testing
- not run (docs change)


------
https://chatgpt.com/codex/tasks/task_e_690ca95a6e508330ad7211e07892be91