### PR TITLE
Defer system app registration to avoid circular imports

### DIFF
--- a/freeadmin/core/runtime/hub.py
+++ b/freeadmin/core/runtime/hub.py
@@ -127,14 +127,20 @@ class AdminHub:
     def _load_system_app(self):
         """Instantiate the built-in system app configuration."""
 
+        if getattr(boot_admin, "_system_app", None) is not None:
+            return boot_admin._system_app
+
         from ...contrib.apps.system.apps import SystemAppConfig
 
-        return SystemAppConfig()
+        system_app = SystemAppConfig()
+        boot_admin._system_app = system_app
+        return system_app
 
     def _ensure_system_app_ready(self) -> None:
         """Load and register the system application once before mounting."""
 
-        if self._system_app_ready:
+        if self._system_app_ready or getattr(self._system_app, "_ready", False):
+            self._system_app_ready = True
             return
         self._system_app.ready(self.admin_site)
         self._system_app_ready = True


### PR DESCRIPTION
## Summary
- delay registering the built-in system app until router creation to prevent runtime circular imports
- guard system app activation with a readiness check to ensure menus populate before mounting the admin interface

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921991d66488330945eb9dd7aad8878)