### PR TITLE
Ensure AdminHub uses configured adapter

### DIFF
--- a/freeadmin/core/boot/manager.py
+++ b/freeadmin/core/boot/manager.py
@@ -203,9 +203,12 @@ class BootManager:
         """Return the cached admin hub instance, importing on first access."""
 
         if self._hub is None:
-            from ..runtime.hub import hub as admin_hub
+            import freeadmin.core.runtime.hub as runtime_hub
+            from ..runtime.hub import AdminHub
 
-            self._hub = admin_hub
+            self._hub = AdminHub(adapter=self.adapter)
+            runtime_hub.hub = self._hub
+            runtime_hub.admin_site = self._hub.admin_site
         return self._hub
 
     def _ensure_system_app(self) -> "SystemAppConfig":

--- a/freeadmin/core/boot/manager.py
+++ b/freeadmin/core/boot/manager.py
@@ -206,9 +206,20 @@ class BootManager:
             import freeadmin.core.runtime.hub as runtime_hub
             from ..runtime.hub import AdminHub
 
-            self._hub = AdminHub(adapter=self.adapter)
-            runtime_hub.hub = self._hub
-            runtime_hub.admin_site = self._hub.admin_site
+            existing_hub = runtime_hub.hub
+            if existing_hub is not None:
+                existing_adapter = existing_hub.admin_site.adapter
+                if self._adapter is None:
+                    self._adapter = existing_adapter
+                elif existing_adapter is not self._adapter:
+                    raise RuntimeError(
+                        "Admin hub already initialized with a different adapter"
+                    )
+                self._hub = existing_hub
+            else:
+                self._hub = AdminHub(adapter=self.adapter)
+                runtime_hub.hub = self._hub
+                runtime_hub.admin_site = self._hub.admin_site
         return self._hub
 
     def _ensure_system_app(self) -> "SystemAppConfig":


### PR DESCRIPTION
## Summary
- allow AdminHub to accept a supplied adapter or boot manager when building the admin site
- instantiate the admin hub with the active adapter inside BootManager and update module exports for existing imports

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921dc44e88c8330bc60dac367f65e0f)