### PR TITLE
Ensure system app registrations use boot adapter

### DIFF
--- a/freeadmin/contrib/apps/system/admins.py
+++ b/freeadmin/contrib/apps/system/admins.py
@@ -12,12 +12,15 @@ Email: timurkady@yandex.com
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Iterable, TYPE_CHECKING
 
 from freeadmin.core.interface.models import ModelAdmin
 from freeadmin.contrib.widgets import Select2Widget
 
 from .exports import SystemAdapterExports
+
+if TYPE_CHECKING:  # pragma: no cover - import for typing only
+    from freeadmin.core.boot import BootManager
 
 
 @dataclass
@@ -45,10 +48,16 @@ class SystemAdminRegistration:
 class SystemAdminRegistrar:
     """Register adapter-aware system admins against an admin site."""
 
-    def __init__(self, exports: SystemAdapterExports | None = None) -> None:
+    def __init__(
+        self,
+        exports: SystemAdapterExports | None = None,
+        boot_manager: "BootManager | None" = None,
+    ) -> None:
         """Store adapter exports used to resolve models for admin classes."""
 
-        self._exports = exports or SystemAdapterExports()
+        self._exports = exports or SystemAdapterExports(boot_manager)
+        if boot_manager is not None:
+            self._exports.boot_manager = boot_manager
 
     @property
     def exports(self) -> SystemAdapterExports:

--- a/freeadmin/contrib/apps/system/apps.py
+++ b/freeadmin/contrib/apps/system/apps.py
@@ -17,6 +17,7 @@ from .urls import SystemURLRegistrar
 
 if TYPE_CHECKING:  # pragma: no cover - import for typing only
     from freeadmin.core.interface.site import AdminSite
+    from freeadmin.core.boot import BootManager
 
 
 class SystemAppConfig:
@@ -26,9 +27,10 @@ class SystemAppConfig:
     label: ClassVar[str] = "system"
     verbose_name: ClassVar[str] = "System Administration"
 
-    def __init__(self) -> None:
+    def __init__(self, boot_manager: "BootManager | None" = None) -> None:
         """Initialize registrars required by the system application."""
 
+        self._boot_manager = boot_manager
         self._urls = SystemURLRegistrar()
 
     @property
@@ -37,12 +39,24 @@ class SystemAppConfig:
 
         return self._urls
 
+    @property
+    def boot_manager(self) -> "BootManager | None":
+        """Return the boot manager associated with this app config."""
+
+        return self._boot_manager
+
+    @boot_manager.setter
+    def boot_manager(self, boot_manager: "BootManager | None") -> None:
+        """Update the boot manager associated with this app config."""
+
+        self._boot_manager = boot_manager
+
     def ready(self, site: "AdminSite") -> None:
         """Register built-in model admins and URLs against ``site``."""
 
         from .admins import SystemAdminRegistrar
 
-        SystemAdminRegistrar().register(site)
+        SystemAdminRegistrar(boot_manager=self._boot_manager).register(site)
         self._urls.register(site)
 
 

--- a/freeadmin/contrib/apps/system/exports.py
+++ b/freeadmin/contrib/apps/system/exports.py
@@ -22,6 +22,18 @@ class SystemAdapterExports:
         self._boot = boot_manager or boot_admin
 
     @property
+    def boot_manager(self) -> BootManager:
+        """Return the boot manager powering these exports."""
+
+        return self._boot
+
+    @boot_manager.setter
+    def boot_manager(self, boot_manager: BootManager) -> None:
+        """Update the boot manager backing adapter-bound attributes."""
+
+        self._boot = boot_manager
+
+    @property
     def adapter(self):
         """Return the active adapter powering the system application."""
 

--- a/freeadmin/core/boot/manager.py
+++ b/freeadmin/core/boot/manager.py
@@ -228,7 +228,9 @@ class BootManager:
         if self._system_app is None:
             from ...contrib.apps.system.apps import SystemAppConfig
 
-            self._system_app = SystemAppConfig()
+            self._system_app = SystemAppConfig(self)
+        else:
+            self._system_app.boot_manager = self
         return self._system_app
 
     def reset(self) -> None:


### PR DESCRIPTION
## Summary
- allow system adapter exports to track the boot manager that initialized them
- thread boot manager references through system app config and admin registrar so registrations use the active adapter
- sync boot manager initialization with system app setup to keep admin menus consistent across adapters

## Testing
- pytest tests/test_settings_export.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921e26b16608330b08f98fb237fe60e)