### PR TITLE
Add integration coverage for boot adapters

### DIFF
--- a/docs/admin/adapter.md
+++ b/docs/admin/adapter.md
@@ -35,17 +35,24 @@ The admin panel interacts with the database exclusively through an adapter objec
 This adapter encapsulates ORM-specific operations behind a shared interface, letting you swap Tortoise, SQLAlchemy, or any other ORM without touching the rest of the admin code.
 
 ### Loading an Adapter
-An adapter instance is registered at startup (see boot_admin usage in admin modules).
-When the admin panel boots, it imports the desired adapter and exposes it via boot_admin.adapter.
-All database calls route through this object.
+The recommended entry point for adapter access is the :class:`~freeadmin.core.boot.BootManager`
+instance coordinating your application boot. Each boot manager exposes its active adapter via
+``boot_manager.adapter`` and propagates that adapter into the runtime hub (``runtime_hub.admin_site.adapter``).
+This keeps discovery, registration, and finalisation aligned with the adapter selected for the
+current application instance—especially when custom adapters coexist alongside the bundled
+defaults.
 
 ```python
-from freeadmin.core.boot import admin as boot_admin
+from freeadmin.core.boot import BootManager
 
-adapter = boot_admin.adapter
+boot = BootManager(adapter_name="my_adapter")
+adapter = boot.adapter
 ```
 
-Each adapter must provide the same set of methods, outlined below.
+Avoid importing ``boot_admin`` directly when working with alternative adapters. The ``boot_admin``
+singleton exists for backwards compatibility and always targets the default adapter; relying on
+it will bypass any adapter registered on a custom ``BootManager``. Each adapter must provide the
+same set of methods, outlined below.
 
 ### Required Interface
 

--- a/docs/admin/boot.md
+++ b/docs/admin/boot.md
@@ -29,7 +29,10 @@ own adapter by creating an instance that implements the adapter protocol and
 registering it with ``freeadmin.contrib.adapters.registry`` before referencing the name
 with ``admin.init``. Existing adapter instances should be registered with the
 registry rather than passed directly to ``BootManager.init`` so they can be
-reused across the runtime.
+reused across the runtime. Access the active adapter through the
+``BootManager.adapter`` property (or ``runtime_hub.admin_site.adapter``) so that
+custom adapters selected at boot are propagated consistently across discovery,
+registration, and finalisation.
 
 ## BootManager responsibilities
 

--- a/tests/multiadapterapp/__init__.py
+++ b/tests/multiadapterapp/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""multiadapterapp
+
+Application package used to verify BootManager adapter selection."""
+
+from __future__ import annotations
+
+from .app import MultiAdapterAdmin, MultiAdapterAppConfig, default
+
+__all__ = ["MultiAdapterAdmin", "MultiAdapterAppConfig", "default"]
+
+
+# The End

--- a/tests/multiadapterapp/app.py
+++ b/tests/multiadapterapp/app.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+"""Application configuration registering admins during startup."""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+from freeadmin.core.interface.app import AppConfig
+from tests.multiadapterapp.models import MultiAdapterModel
+
+
+class MultiAdapterAdmin:
+    """Registerable admin class storing adapter references for assertions."""
+
+    def __init__(self, site, app_label: str, model_slug: str, adapter) -> None:
+        """Store the adapter used for registration and basic metadata."""
+
+        self.site = site
+        self.app_label = app_label
+        self.model_slug = model_slug
+        self.adapter = adapter
+
+    def get_verbose_name_plural(self) -> str:
+        """Return the human-readable name for menu rendering."""
+
+        return "Adapters"
+
+
+class MultiAdapterAppConfig(AppConfig):
+    """Track lifecycle hooks and register admin definitions for testing."""
+
+    app_label = "multiadapter"
+    name = "tests.multiadapterapp"
+
+    def __init__(self) -> None:
+        """Initialize counters verifying startup execution."""
+
+        super().__init__()
+        self.ready_calls = 0
+
+    async def startup(self) -> None:
+        """Register admin entries to drive menu and registry assertions."""
+
+        self.ready_calls += 1
+        runtime_hub = import_module("freeadmin.core.runtime.hub")
+        runtime_hub.admin_site.register(
+            app=self.app_label,
+            model=MultiAdapterModel,
+            admin_cls=MultiAdapterAdmin,
+            icon="bi-stars",
+        )
+
+
+default = MultiAdapterAppConfig()
+
+__all__ = ["MultiAdapterAppConfig", "default", "MultiAdapterAdmin"]
+
+
+# The End

--- a/tests/multiadapterapp/models.py
+++ b/tests/multiadapterapp/models.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""In-memory models used for adapter integration tests."""
+
+from __future__ import annotations
+
+
+class MultiAdapterModel:
+    """Lightweight model representation for menu registration."""
+
+    def __init__(self) -> None:
+        """Create an empty model instance for compatibility hooks."""
+
+        self.id: int | None = None
+
+
+class MemoryContentType:
+    """Represent the admin content type tracked during finalization."""
+
+    def __init__(
+        self,
+        *,
+        app_label: str,
+        model: str,
+        dotted: str,
+        is_registered: bool = True,
+        identifier: int | None = None,
+    ) -> None:
+        """Store identifying attributes and optional primary key."""
+
+        self.id = identifier
+        self.app_label = app_label
+        self.model = model
+        self.dotted = dotted
+        self.is_registered = is_registered
+
+
+class MemorySystemSetting:
+    """Simplified system setting model used by in-memory adapters."""
+
+    def __init__(self, *, key: str, name: str, value, value_type: str) -> None:
+        """Persist key, name, value, and value type for assertions."""
+
+        self.id: int | None = None
+        self.key = key
+        self.name = name
+        self.value = value
+        self.value_type = value_type
+
+
+class MemoryUser:
+    """Placeholder user model required for adapter validation."""
+
+    def __init__(self, username: str = "user") -> None:
+        """Store the username field for compatibility."""
+
+        self.id: int | None = None
+        self.username = username
+
+
+class MemoryGroup:
+    """Placeholder group model required for adapter validation."""
+
+    def __init__(self, name: str = "group") -> None:
+        """Store the group name for compatibility."""
+
+        self.id: int | None = None
+        self.name = name
+
+
+class MemoryPermission:
+    """Placeholder permission model required for adapter validation."""
+
+    def __init__(self, owner=None) -> None:
+        """Store the permission owner for compatibility."""
+
+        self.id: int | None = None
+        self.owner = owner
+
+
+class MemoryEnum:
+    """Minimal enumeration stand-in for adapter validation."""
+
+    def __init__(self, label: str = "enum") -> None:
+        """Retain a label describing the enumeration member."""
+
+        self.label = label
+
+
+__all__ = [
+    "MemoryContentType",
+    "MemoryEnum",
+    "MemoryGroup",
+    "MemoryPermission",
+    "MemorySystemSetting",
+    "MemoryUser",
+    "MultiAdapterModel",
+]
+
+
+# The End

--- a/tests/test_boot_manager_multi_adapter_integration.py
+++ b/tests/test_boot_manager_multi_adapter_integration.py
@@ -1,0 +1,347 @@
+# -*- coding: utf-8 -*-
+"""Integration tests verifying boot sequence preserves adapter selections."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from importlib import import_module
+from typing import Any, Dict, Iterable, List, Tuple
+import sys
+import types
+
+import pytest
+from fastapi import FastAPI
+
+from freeadmin.contrib.adapters import registry as adapter_registry
+from freeadmin.core.boot import BootManager
+from freeadmin.core.interface.settings.config import system_config
+from tests.multiadapterapp.models import (
+    MemoryContentType,
+    MemoryEnum,
+    MemoryGroup,
+    MemoryPermission,
+    MemorySystemSetting,
+    MemoryUser,
+    MultiAdapterModel,
+)
+
+runtime_hub_module = import_module("freeadmin.core.runtime.hub")
+
+
+class MemoryAdapter:
+    """In-memory adapter satisfying the admin protocol for testing."""
+
+    QuerySet = list
+    DoesNotExist = LookupError
+    MultipleObjectsReturned = RuntimeError
+    IntegrityError = RuntimeError
+
+    def __init__(self, name: str) -> None:
+        """Initialize storage and bind adapter metadata."""
+
+        self.name = name
+        self.model_modules: list[str] = []
+        self.user_model = MemoryUser
+        self.group_model = MemoryGroup
+        self.group_permission_model = MemoryPermission
+        self.user_permission_model = MemoryPermission
+        self.content_type_model = MemoryContentType
+        self.system_setting_model = MemorySystemSetting
+        self.perm_action = MemoryEnum
+        self.setting_value_type = MemoryEnum
+        self._storage: Dict[type, List[Any]] = {}
+        self._next_ids: Dict[type, int] = {}
+
+    def get_model_descriptor(self, model: type[Any]) -> dict[str, Any]:
+        """Return a descriptor describing the provided model class."""
+
+        return {"model": model}
+
+    def get_model(self, dotted: str) -> type[Any]:
+        """Resolve a dotted path into a model class from storage."""
+
+        for model_cls in self._storage:
+            if model_cls.__name__ == dotted.split(".")[-1]:
+                return model_cls
+        raise LookupError(f"Unknown model {dotted}")
+
+    def get_pk_attr(self, model: type[Any]) -> str:
+        """Return the attribute name used as a primary key."""
+
+        _ = model
+        return "id"
+
+    def all(self, qs_or_model: Any) -> list[Any]:
+        """Return all records associated with ``qs_or_model``."""
+
+        model = qs_or_model if isinstance(qs_or_model, type) else type(qs_or_model)
+        return list(self._storage.get(model, []))
+
+    def filter(self, qs_or_model: Any, **filters: Any) -> list[Any]:
+        """Return a filtered list of records matching ``filters``."""
+
+        queryset = qs_or_model if isinstance(qs_or_model, list) else self.all(qs_or_model)
+        results: list[Any] = []
+        for obj in queryset:
+            if all(getattr(obj, key, None) == value for key, value in filters.items()):
+                results.append(obj)
+        return results
+
+    def apply_filter_spec(self, qs_or_model: Any, specs: list[Any]) -> list[Any]:
+        """Apply filter specs sequentially to the provided queryset or model."""
+
+        queryset = qs_or_model if isinstance(qs_or_model, list) else self.all(qs_or_model)
+        filtered = list(queryset)
+        for spec in specs:
+            filtered = [obj for obj in filtered if spec(obj)]
+        return filtered
+
+    def order_by(self, qs: list[Any], *fields: str) -> list[Any]:
+        """Sort ``qs`` by the supplied ``fields`` in insertion order."""
+
+        ordered = list(qs)
+        for field in reversed(fields):
+            ordered.sort(key=lambda obj: getattr(obj, field, None))
+        return ordered
+
+    def limit(self, qs: list[Any], limit: int) -> list[Any]:
+        """Return the first ``limit`` records from ``qs``."""
+
+        return list(qs)[:limit]
+
+    def offset(self, qs: list[Any], offset: int) -> list[Any]:
+        """Return ``qs`` starting at the provided ``offset``."""
+
+        return list(qs)[offset:]
+
+    def select_related(self, qs: list[Any], *related: str) -> list[Any]:
+        """Return ``qs`` unchanged; relation loading is unnecessary."""
+
+        _ = related
+        return list(qs)
+
+    def prefetch_related(self, qs: list[Any], *related: str) -> list[Any]:
+        """Return ``qs`` unchanged; relation loading is unnecessary."""
+
+        _ = related
+        return list(qs)
+
+    def annotate(self, qs: list[Any], annotations: dict) -> list[Any]:
+        """Return ``qs`` unchanged because annotations are unused in tests."""
+
+        _ = annotations
+        return list(qs)
+
+    def distinct(self, qs: list[Any], *fields: str) -> list[Any]:
+        """Return distinct values by ``fields`` preserving order."""
+
+        _ = fields
+        seen: set[int] = set()
+        unique: list[Any] = []
+        for obj in qs:
+            identity = id(obj)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            unique.append(obj)
+        return unique
+
+    def only(self, qs: list[Any], *fields: str) -> list[Any]:
+        """Return ``qs`` unchanged; field projection is unnecessary."""
+
+        _ = fields
+        return list(qs)
+
+    def values(self, qs: list[Any], *fields: str) -> list[dict]:
+        """Return dictionaries containing selected ``fields`` from ``qs``."""
+
+        payload: list[dict] = []
+        for obj in qs:
+            record = {field: getattr(obj, field, None) for field in fields}
+            payload.append(record)
+        return payload
+
+    async def fetch_all(self, qs: Iterable[Any]) -> list[Any]:
+        """Return all items from ``qs`` as a list."""
+
+        return list(qs)
+
+    async def fetch_values(self, qs: Iterable[Any], *fields: str, flat: bool = False) -> list[Any]:
+        """Return selected values from ``qs`` respecting ``flat``."""
+
+        records = []
+        for obj in qs:
+            values = [getattr(obj, field, None) for field in fields]
+            records.append(values[0] if flat and values else tuple(values))
+        return records
+
+    async def count(self, qs: Iterable[Any]) -> int:
+        """Return the number of records in ``qs``."""
+
+        return len(list(qs))
+
+    async def get(self, qs_or_model: Any, **filters: Any) -> Any:
+        """Return a single record matching ``filters`` or raise."""
+
+        matches = self.filter(qs_or_model, **filters)
+        if not matches:
+            raise self.DoesNotExist
+        if len(matches) > 1:
+            raise self.MultipleObjectsReturned
+        return matches[0]
+
+    async def get_or_none(self, qs_or_model: Any, **filters: Any) -> Any | None:
+        """Return a single record matching ``filters`` or ``None``."""
+
+        try:
+            return await self.get(qs_or_model, **filters)
+        except self.DoesNotExist:
+            return None
+
+    async def exists(self, qs: Iterable[Any]) -> bool:
+        """Return ``True`` when ``qs`` contains at least one record."""
+
+        return any(True for _ in qs)
+
+    async def save(self, obj: Any) -> None:
+        """Persist ``obj`` assigning an identifier when missing."""
+
+        model = type(obj)
+        bucket = self._storage.setdefault(model, [])
+        if getattr(obj, "id", None) is None:
+            next_id = self._next_ids.get(model, 1)
+            obj.id = next_id
+            self._next_ids[model] = next_id + 1
+            bucket.append(obj)
+            return
+        for index, record in enumerate(bucket):
+            if getattr(record, "id", None) == getattr(obj, "id", None):
+                bucket[index] = obj
+                break
+        else:
+            bucket.append(obj)
+
+    async def delete(self, obj: Any) -> None:
+        """Remove ``obj`` from storage if present."""
+
+        model = type(obj)
+        bucket = self._storage.get(model, [])
+        self._storage[model] = [record for record in bucket if record is not obj]
+
+    async def create(self, model: type[Any], **data: Any) -> Any:
+        """Create, persist, and return an instance of ``model``."""
+
+        instance = model(**data)
+        await self.save(instance)
+        return instance
+
+    async def values_list(self, qs: Iterable[Any], *fields: str, flat: bool = False) -> list[Any]:
+        """Return positional values from ``qs`` respecting ``flat``."""
+
+        return await self.fetch_values(qs, *fields, flat=flat)
+
+    def Q(self, *args: Any, **kwargs: Any) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        """Return a tuple capturing provided query arguments."""
+
+        _ = args
+        return args, kwargs
+
+    @asynccontextmanager
+    async def in_transaction(self):
+        """Provide a no-op transaction context manager."""
+
+        yield None
+
+    async def m2m_clear(self, manager: Any) -> None:
+        """Clear relations managed by ``manager`` when applicable."""
+
+        _ = manager
+        return None
+
+    async def m2m_add(self, manager: Any, objs: Iterable[Any]) -> None:
+        """Attach ``objs`` to ``manager`` when applicable."""
+
+        _ = manager, objs
+        return None
+
+
+class BootHarness:
+    """Coordinate boot, discovery, and finalization for a specific adapter."""
+
+    def __init__(self, adapter_name: str) -> None:
+        """Store adapter selection for later bootstrapping."""
+
+        self.adapter_name = adapter_name
+
+    async def run(self, packages: list[str]) -> tuple[Any, list[Any]]:
+        """Execute boot and startup hooks, returning the admin site and menu."""
+
+        runtime_module = sys.modules.get("freeadmin.core.runtime.hub") or runtime_hub_module
+        if not isinstance(runtime_module, types.ModuleType):
+            runtime_module = import_module("freeadmin.core.runtime.hub")
+        elif not hasattr(runtime_module, "hub"):
+            runtime_module = import_module("freeadmin.core.runtime.hub")
+        sys.modules["freeadmin.core.runtime.hub"] = runtime_module
+        runtime_package = sys.modules.get("freeadmin.core.runtime")
+        if runtime_package is not None:
+            runtime_package.hub = runtime_module
+            runtime_package.admin_site = getattr(runtime_module, "admin_site", None)
+        original_hub = getattr(runtime_module, "hub", None)
+        original_admin_site = getattr(runtime_module, "admin_site", None)
+        runtime_module.hub = None
+        runtime_module.admin_site = None
+        boot = BootManager(adapter_name=self.adapter_name)
+        app = FastAPI()
+        try:
+            boot.init(app, packages=packages)
+            await app.router.startup()
+            site = runtime_module.admin_site
+            menu = site.menu_builder.build_main_menu(locale="en")
+            await app.router.shutdown()
+            boot.reset()
+            return site, menu
+        finally:
+            runtime_module.hub = original_hub
+            runtime_module.admin_site = original_admin_site
+
+
+@pytest.fixture(autouse=True)
+def _patch_system_config(monkeypatch):
+    """Stub configuration hooks to avoid touching external databases."""
+
+    async def _noop() -> None:
+        return None
+
+    monkeypatch.setattr(system_config, "ensure_seed", _noop)
+    monkeypatch.setattr(system_config, "reload", _noop)
+    system_config._cache.clear()
+    yield
+
+
+@pytest.mark.asyncio
+async def test_boot_sequence_uses_selected_adapter(monkeypatch) -> None:
+    """Ensure discovery and finalization rely on the BootManager's adapter."""
+
+    adapter_alpha = MemoryAdapter("alpha")
+    adapter_beta = MemoryAdapter("beta")
+    adapter_registry.register(adapter_alpha)
+    adapter_registry.register(adapter_beta)
+
+    harness_alpha = BootHarness(adapter_alpha.name)
+    site_alpha, menu_alpha = await harness_alpha.run(["tests.multiadapterapp"])
+
+    admin_entry_alpha = site_alpha.model_reg[("multiadapter", "multiadaptermodel")]
+    assert admin_entry_alpha.adapter is adapter_alpha
+    assert any(item.path.endswith("/multiadapter/multiadaptermodel") for item in menu_alpha)
+
+    harness_beta = BootHarness(adapter_beta.name)
+    site_beta, menu_beta = await harness_beta.run(["tests.multiadapterapp"])
+
+    admin_entry_beta = site_beta.model_reg[("multiadapter", "multiadaptermodel")]
+    assert admin_entry_beta.adapter is adapter_beta
+    assert any(item.path.endswith("/multiadapter/multiadaptermodel") for item in menu_beta)
+    assert site_alpha.adapter is adapter_alpha
+    assert site_beta.adapter is adapter_beta
+
+
+# The End


### PR DESCRIPTION
## Summary
- add in-memory multi-adapter application fixture to verify boot, discovery, and finalisation flows
- introduce integration test ensuring BootManager-selected adapters retain registry and menu entries across runs
- document using BootManager and the runtime hub to access adapters instead of the legacy boot_admin singleton

## Testing
- pytest tests/test_boot_manager_multi_adapter_integration.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921e7bdab008330a3f455e45a43e86f)