### PR TITLE
Fix BootManager runtime hub import

### DIFF
--- a/freeadmin/core/boot/manager.py
+++ b/freeadmin/core/boot/manager.py
@@ -271,10 +271,10 @@ class BootManager:
         """Return the cached admin hub instance, importing on first access."""
 
         if self._hub is None:
-            import freeadmin.core.runtime.hub as runtime_hub
+            runtime_hub = import_module("freeadmin.core.runtime.hub")
             from ..runtime.hub import AdminHub
 
-            existing_hub = runtime_hub.hub
+            existing_hub = getattr(runtime_hub, "hub", None)
             if existing_hub is not None:
                 existing_adapter = existing_hub.admin_site.adapter
                 if self._adapter is None:


### PR DESCRIPTION
## Summary
- ensure the boot manager imports the runtime hub module explicitly to avoid alias conflicts
- safely access the existing hub instance when reusing initialized adapters

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921f5b92bd48330b5fd219ead57988c)