### PR TITLE
Add admin context flag for menu rendering

### DIFF
--- a/freeadmin/core/interface/context.py
+++ b/freeadmin/core/interface/context.py
@@ -136,6 +136,7 @@ class TemplateContextBuilder:
             "system_config": system_config,
             "site_title": admin_site.title,
             "brand_icon": admin_site.brand_icon,
+            "is_admin_request": True,
             "prefix": admin_prefix,
             "ORM_PREFIX": orm_prefix,
             "SETTINGS_PREFIX": settings_prefix,

--- a/tests/test_admin_template_context.py
+++ b/tests/test_admin_template_context.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""admin template context
+
+Validate that admin template context exposes layout-related flags."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from starlette.requests import Request
+
+from freeadmin.core.interface.context import TemplateContextBuilder
+from freeadmin.core.interface.site import AdminSite
+
+
+class DummyAdapter:
+    """Minimal adapter satisfying the admin site's contract for tests."""
+
+    content_type_model = object()
+    IntegrityError = Exception
+
+
+class AdminContextFactory:
+    """Provide helpers for constructing admin context test fixtures."""
+
+    def __init__(self) -> None:
+        """Initialise reusable factory state for admin context tests."""
+
+    def create_site(self) -> AdminSite:
+        """Return a new admin site configured with the dummy adapter."""
+
+        return AdminSite(DummyAdapter(), title="Test Admin")
+
+    def build_request(self, path: str = "/admin/") -> Request:
+        """Construct a Starlette request pointing at ``path``."""
+
+        app = FastAPI()
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": "GET",
+            "path": path,
+            "raw_path": path.encode("utf-8"),
+            "root_path": "",
+            "scheme": "http",
+            "query_string": b"",
+            "headers": [],
+            "client": ("testclient", 80),
+            "server": ("testserver", 80),
+            "app": app,
+        }
+        return Request(scope)
+
+
+def test_admin_context_marks_admin_request() -> None:
+    """Ensure admin context explicitly flags administrative requests."""
+
+    factory = AdminContextFactory()
+    site = factory.create_site()
+    request = factory.build_request()
+
+    context = TemplateContextBuilder(site).build(request, user=None)
+
+    assert context["is_admin_request"] is True
+    assert context["prefix"] == "/admin"
+
+
+# The End
+


### PR DESCRIPTION
## Summary
- set the admin template context to mark administrative requests so the navbar displays correctly
- add a focused test covering the admin context flag

## Testing
- pytest tests/test_admin_template_context.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692211cbb9448330bcaa5a5d5abc0a8b)