### PR TITLE
Refresh system settings cache on admin changes

### DIFF
--- a/freeadmin/contrib/apps/system/admins.py
+++ b/freeadmin/contrib/apps/system/admins.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from typing import Iterable, TYPE_CHECKING
 
 from freeadmin.core.interface.models import ModelAdmin
+from freeadmin.core.interface.settings import system_config
 from freeadmin.contrib.widgets import Select2Widget
 
 from .exports import SystemAdapterExports
@@ -168,6 +169,20 @@ class SystemSettingAdmin(ModelAdmin):
         """Meta options for :class:`SystemSettingAdmin`."""
 
         pass
+
+    async def create(self, request, user, md, payload):
+        """Create a system setting and refresh the cached configuration."""
+
+        obj = await super().create(request, user, md, payload)
+        await system_config.reload()
+        return obj
+
+    async def update(self, request, user, md, obj, payload):
+        """Update a system setting and refresh the cached configuration."""
+
+        updated_obj = await super().update(request, user, md, obj, payload)
+        await system_config.reload()
+        return updated_obj
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- reload the system configuration cache when system settings are created or updated via the admin panel
- ensure admin UI reflects changes such as custom titles without restarting

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922d6756afc83309fe6ec318b7b3ff1)