### PR TITLE
Ensure runtime settings apply immediately across admin routes

### DIFF
--- a/freeadmin/core/network/router/aggregator.py
+++ b/freeadmin/core/network/router/aggregator.py
@@ -39,10 +39,7 @@ class RouterAggregator(RouterFoundation):
 
         super().__init__(settings=settings, template_service=template_service)
         self.site = site
-        default_prefix = system_config.get_cached(
-            SettingsKey.ADMIN_PREFIX, self._settings.admin_path
-        )
-        self._prefix = (prefix or default_prefix).rstrip("/")
+        self._explicit_prefix = prefix.rstrip("/") if prefix else None
         self._admin_router: APIRouter | None = None
         self._mounted_apps: WeakSet[FastAPI] = WeakSet()
         self._additional_routers: list[tuple[APIRouter, str | None]] = list(
@@ -53,7 +50,11 @@ class RouterAggregator(RouterFoundation):
     def prefix(self) -> str:
         """Return the current prefix used for mounting the admin router."""
 
-        return self._prefix
+        if self._explicit_prefix is not None:
+            return self._explicit_prefix
+        return system_config.get_cached(
+            SettingsKey.ADMIN_PREFIX, self._settings.admin_path
+        ).rstrip("/")
 
     def create_admin_router(self) -> APIRouter:
         """Instantiate the FastAPI router for the admin site."""
@@ -75,15 +76,16 @@ class RouterAggregator(RouterFoundation):
     def mount(self, app: FastAPI, prefix: str | None = None) -> None:
         """Mount the admin router and any configured extras onto the app."""
 
-        self._prefix = (prefix or self._prefix).rstrip("/")
+        if prefix is not None:
+            self._explicit_prefix = prefix.rstrip("/")
         self.ensure_site_templates(self.site)
         app.state.admin_site = self.site
         if app in self._mounted_apps:
             return
 
         router = self.get_admin_router()
-        app.include_router(router, prefix=self._prefix)
-        self.mount_static_resources(app, self._prefix)
+        app.include_router(router, prefix=self.prefix)
+        self.mount_static_resources(app, self.prefix)
         self.register_additional_routers(app)
         self._mounted_apps.add(app)
 
@@ -183,7 +185,8 @@ class ExtendedRouterAggregator(RouterAggregator):
     def mount(self, app: FastAPI, prefix: str | None = None) -> None:
         """Mount public and admin routers onto ``app`` respecting order."""
 
-        self._prefix = (prefix or self._prefix).rstrip("/")
+        if prefix is not None:
+            self._explicit_prefix = prefix.rstrip("/")
         self.ensure_site_templates(self.site)
         app.state.admin_site = self.site
         if app in self._mounted_apps:
@@ -191,7 +194,7 @@ class ExtendedRouterAggregator(RouterAggregator):
 
         for router, router_prefix in self.get_routers():
             app.include_router(router, prefix=router_prefix or "")
-        self.mount_static_resources(app, self._prefix)
+        self.mount_static_resources(app, self.prefix)
         self._mounted_apps.add(app)
 
     @property

--- a/freeadmin/core/runtime/hub.py
+++ b/freeadmin/core/runtime/hub.py
@@ -48,7 +48,7 @@ class AdminHub:
         """Initialize the admin site using the provided adapter."""
 
         self._settings = settings or current_settings()
-        site_title = title or self._settings.admin_site_title
+        site_title = title if title is not None else None
         selected_adapter = self._select_adapter(adapter=adapter, boot_manager=boot_manager)
         self.admin_site = AdminSite(
             selected_adapter, title=site_title, settings=self._settings

--- a/freeadmin/core/runtime/middleware.py
+++ b/freeadmin/core/runtime/middleware.py
@@ -37,9 +37,6 @@ class AdminGuardMiddleware(BaseHTTPMiddleware):
     ) -> None:
         super().__init__(app)
         self._settings = settings or current_settings()
-        self.prefix = system_config.get_cached(
-            SettingsKey.ADMIN_PREFIX, self._settings.admin_path
-        ).rstrip("/")
         self._login_path: str | None = None
         self._logout_path: str | None = None
         self._setup_path: str | None = None
@@ -117,7 +114,12 @@ class AdminGuardMiddleware(BaseHTTPMiddleware):
     def _apply_settings(self, settings: FreeAdminSettings) -> None:
         """Refresh cached prefix and settings after reconfiguration."""
         self._settings = settings
-        self.prefix = system_config.get_cached(
+
+    @property
+    def prefix(self) -> str:
+        """Return the active admin prefix sourced from runtime settings."""
+
+        return system_config.get_cached(
             SettingsKey.ADMIN_PREFIX, self._settings.admin_path
         ).rstrip("/")
 

--- a/tests/test_admin_site_settings.py
+++ b/tests/test_admin_site_settings.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""
+tests.test_admin_site_settings
+
+Validation for admin site settings resolution using runtime configuration.
+
+Version:0.1.0
+Author: Timur Kady
+Email: timurkady@yandex.com
+"""
+
+from __future__ import annotations
+
+from freeadmin.core.configuration.conf import FreeAdminSettings
+from freeadmin.core.interface.settings import SettingsKey, system_config
+from freeadmin.core.runtime.hub import AdminHub
+
+
+def test_admin_site_title_uses_runtime_settings(monkeypatch) -> None:
+    """Admin site title should reflect database-backed runtime settings."""
+
+    original_cache = dict(system_config._cache)  # type: ignore[attr-defined]
+    try:
+        system_config._cache.clear()  # type: ignore[attr-defined]
+        system_config._cache[SettingsKey.DEFAULT_ADMIN_TITLE.value] = "Runtime Title"  # type: ignore[attr-defined]
+        hub = AdminHub(settings=FreeAdminSettings())
+
+        assert hub.admin_site.title == "Runtime Title"
+    finally:
+        system_config._cache.clear()  # type: ignore[attr-defined]
+        system_config._cache.update(original_cache)  # type: ignore[attr-defined]
+
+
+def test_admin_site_title_respects_override(monkeypatch) -> None:
+    """Explicitly provided admin titles must override runtime settings."""
+
+    original_cache = dict(system_config._cache)  # type: ignore[attr-defined]
+    try:
+        system_config._cache.clear()  # type: ignore[attr-defined]
+        system_config._cache[SettingsKey.DEFAULT_ADMIN_TITLE.value] = "Runtime Title"  # type: ignore[attr-defined]
+        hub = AdminHub(title="Static Title", settings=FreeAdminSettings())
+
+        assert hub.admin_site.title == "Static Title"
+    finally:
+        system_config._cache.clear()  # type: ignore[attr-defined]
+        system_config._cache.update(original_cache)  # type: ignore[attr-defined]
+
+
+# The End
+
+

--- a/tests/test_system_settings_runtime_updates.py
+++ b/tests/test_system_settings_runtime_updates.py
@@ -1,0 +1,126 @@
+"""system settings runtime updates
+
+Verify that runtime settings pulled from the database are applied immediately
+across middleware, routing, and template contexts.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import pytest
+from starlette.requests import Request
+
+from freeadmin.core.configuration.conf import FreeAdminSettings
+from freeadmin.core.interface.settings import SettingsKey, system_config
+from freeadmin.core.network.router.aggregator import RouterAggregator
+from freeadmin.core.runtime.middleware import AdminGuardMiddleware
+from freeadmin.core.interface.templates.rendering import PageTemplateResponder
+
+
+class DummySite:
+    """Minimal site stub for router initialisation."""
+
+    def __init__(self) -> None:
+        """Prepare placeholder adapter reference."""
+
+        self.adapter = object()
+
+
+class DummyApp:
+    """Simple ASGI application placeholder."""
+
+    def __init__(self) -> None:
+        """Initialize with a no-op admin site placeholder."""
+
+        self.state = type("State", (), {"admin_site": None})()
+
+    async def __call__(self, scope: dict[str, Any], receive: Callable, send: Callable) -> None:
+        """ASGI entrypoint stub required by Starlette middleware."""
+
+        return None
+
+
+class TestRuntimeSettingsPropagation:
+    """Ensure runtime settings updates are visible without restarts."""
+
+    @pytest.fixture(autouse=True)
+    def clear_system_config_cache(self) -> None:
+        """Reset system configuration cache before and after each test."""
+
+        original = dict(system_config._cache)  # type: ignore[attr-defined]
+        system_config._cache.clear()  # type: ignore[attr-defined]
+        try:
+            yield
+        finally:
+            system_config._cache.clear()  # type: ignore[attr-defined]
+            system_config._cache.update(original)  # type: ignore[attr-defined]
+
+    def test_router_aggregator_tracks_runtime_prefix(self) -> None:
+        """RouterAggregator should reflect admin prefix updates from the cache."""
+
+        system_config._cache[SettingsKey.ADMIN_PREFIX.value] = "/initial-admin"  # type: ignore[attr-defined]
+        aggregator = RouterAggregator(site=DummySite(), settings=FreeAdminSettings())
+
+        assert aggregator.prefix == "/initial-admin"
+
+        system_config._cache[SettingsKey.ADMIN_PREFIX.value] = "/updated-admin"  # type: ignore[attr-defined]
+        assert aggregator.prefix == "/updated-admin"
+
+    def test_admin_guard_prefix_refreshes_after_setting_change(self) -> None:
+        """AdminGuardMiddleware should read the current admin prefix dynamically."""
+
+        system_config._cache[SettingsKey.ADMIN_PREFIX.value] = "/configured-admin"  # type: ignore[attr-defined]
+        middleware = AdminGuardMiddleware(DummyApp(), settings=FreeAdminSettings())
+
+        assert middleware.prefix == "/configured-admin"
+
+        system_config._cache[SettingsKey.ADMIN_PREFIX.value] = "/new-admin"  # type: ignore[attr-defined]
+        assert middleware.prefix == "/new-admin"
+
+    @pytest.mark.asyncio
+    async def test_template_defaults_pull_from_runtime_cache(self) -> None:
+        """Template context defaults should honor updated runtime settings."""
+
+        system_config._cache.update(  # type: ignore[attr-defined]
+            {
+                SettingsKey.DEFAULT_ADMIN_TITLE.value: "Runtime Title",
+                SettingsKey.BRAND_ICON.value: "brand.png",
+                SettingsKey.PUBLIC_PREFIX.value: "/public",
+                SettingsKey.ADMIN_PREFIX.value: "/admin",
+            }
+        )
+
+        scope = {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "GET",
+            "path": "/",
+            "root_path": "",
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "headers": [],
+            "query_string": b"",
+            "client": ("127.0.0.1", 12345),
+        }
+        scope["app"] = DummyApp()
+
+        async def _receive() -> dict[str, Any]:
+            """Provide an empty HTTP request body for template context generation."""
+
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        request = Request(scope, receive=_receive)
+
+        context = PageTemplateResponder._build_default_context(request)
+        assert context["site_title"] == "Runtime Title"
+        assert context["brand_icon"] == "brand.png"
+        assert context["public_prefix"] == "/public"
+        assert context["admin_prefix"] == "/admin"
+
+        system_config._cache[SettingsKey.DEFAULT_ADMIN_TITLE.value] = "Updated Title"  # type: ignore[attr-defined]
+        updated_context = PageTemplateResponder._build_default_context(request)
+        assert updated_context["site_title"] == "Updated Title"
+
+
+# The End


### PR DESCRIPTION
## Summary
- read the admin prefix from runtime system settings in the router aggregator and guard middleware so updates apply without restarts
- add coverage confirming router, middleware, and template contexts reflect database-backed setting changes immediately

## Testing
- pytest tests/test_admin_site_settings.py tests/test_system_settings_runtime_updates.py tests/test_admin_guard_middleware.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922d9088ea4833096d22cf72eb42dc2)