### PR TITLE
Prevent duplicate widget script declarations

### DIFF
--- a/freeadmin/static/widgets/select2.js
+++ b/freeadmin/static/widgets/select2.js
@@ -1,7 +1,13 @@
 // static/widgets/select2.js
 
 // Manager for integrating Select2 with JSONEditor lifecycle events.
-class Select2WidgetManager {
+(() => {
+  const globalSelect2Obj = typeof window !== 'undefined' ? window : globalThis;
+  if (globalSelect2Obj.Select2WidgetManager) {
+    return;
+  }
+
+  class Select2WidgetManager {
   constructor(globalObj) {
     this.global = globalObj;
     this.document = globalObj?.document || null;
@@ -230,11 +236,12 @@ class Select2WidgetManager {
       timer(() => banner.remove(), 5000);
     }
   }
-}
+  }
 
-Select2WidgetManager.instance = null;
+  Select2WidgetManager.instance = null;
 
-const select2GlobalObj = typeof window !== 'undefined' ? window : globalThis;
-Select2WidgetManager.bootstrap(select2GlobalObj);
+  globalSelect2Obj.Select2WidgetManager = Select2WidgetManager;
+  Select2WidgetManager.bootstrap(globalSelect2Obj);
+})();
 
 // # The End

--- a/freeadmin/static/widgets/textarea.js
+++ b/freeadmin/static/widgets/textarea.js
@@ -1,67 +1,71 @@
 // static/widgets/textarea.js
 
-class TextAreaAutoHeight {
-  constructor(textarea) {
-    this.ta = textarea;
-    const style = window.getComputedStyle(this.ta);
-    this.lineHeight = parseFloat(style.lineHeight) || 16;
-    this.maxHeight = this.lineHeight * 10;
-    this._resize();
-    this.ta.addEventListener('input', () => this._resize());
-  }
-
-  _resize() {
-    this.ta.style.height = 'auto';
-    const newHeight = Math.min(this.ta.scrollHeight, this.maxHeight);
-    this.ta.style.height = `${newHeight}px`;
-    this.ta.style.overflowY = this.ta.scrollHeight > this.maxHeight ? 'auto' : 'hidden';
-  }
-
-  static _activate(ta) {
-    if (!ta || ta.dataset.textareaAutoHeightInit) return;
-    ta.dataset.textareaAutoHeightInit = '1';
-    new TextAreaAutoHeight(ta);
-  }
-
-  static init(root = document) {
-    root
-      .querySelectorAll('textarea[data-textarea-autosize]')
-      .forEach(ta => this._activate(ta));
-  }
-
-  static observe() {
-    if (this._observer) return;
-    this._observer = new MutationObserver(mutations => {
-      mutations.forEach(m =>
-        m.addedNodes.forEach(node => {
-          if (node.nodeType === Node.ELEMENT_NODE) {
-            if (node.matches && node.matches('textarea[data-textarea-autosize]')) {
-              this._activate(node);
-            }
-            node
-              .querySelectorAll?.('textarea[data-textarea-autosize]')
-              .forEach(el => this._activate(el));
-          }
-        })
-      );
-    });
-    this._observer.observe(document.documentElement, {
-      childList: true,
-      subtree: true,
-    });
-  }
-
-  static setup() {
-    if (document.readyState !== 'loading') {
-      this.init();
-    } else {
-      document.addEventListener('DOMContentLoaded', () => this.init());
+(() => {
+  class TextAreaAutoHeight {
+    constructor(textarea) {
+      this.ta = textarea;
+      const style = window.getComputedStyle(this.ta);
+      this.lineHeight = parseFloat(style.lineHeight) || 16;
+      this.maxHeight = this.lineHeight * 10;
+      this._resize();
+      this.ta.addEventListener('input', () => this._resize());
     }
-    this.observe();
-  }
-}
 
-TextAreaAutoHeight.setup();
-window.TextAreaAutoHeight = TextAreaAutoHeight;
+    _resize() {
+      this.ta.style.height = 'auto';
+      const newHeight = Math.min(this.ta.scrollHeight, this.maxHeight);
+      this.ta.style.height = `${newHeight}px`;
+      this.ta.style.overflowY = this.ta.scrollHeight > this.maxHeight ? 'auto' : 'hidden';
+    }
+
+    static _activate(ta) {
+      if (!ta || ta.dataset.textareaAutoHeightInit) return;
+      ta.dataset.textareaAutoHeightInit = '1';
+      new TextAreaAutoHeight(ta);
+    }
+
+    static init(root = document) {
+      root
+        .querySelectorAll('textarea[data-textarea-autosize]')
+        .forEach(ta => this._activate(ta));
+    }
+
+    static observe() {
+      if (this._observer) return;
+      this._observer = new MutationObserver(mutations => {
+        mutations.forEach(m =>
+          m.addedNodes.forEach(node => {
+            if (node.nodeType === Node.ELEMENT_NODE) {
+              if (node.matches && node.matches('textarea[data-textarea-autosize]')) {
+                this._activate(node);
+              }
+              node
+                .querySelectorAll?.('textarea[data-textarea-autosize]')
+                .forEach(el => this._activate(el));
+            }
+          })
+        );
+      });
+      this._observer.observe(document.documentElement, {
+        childList: true,
+        subtree: true,
+      });
+    }
+
+    static setup() {
+      if (document.readyState !== 'loading') {
+        this.init();
+      } else {
+        document.addEventListener('DOMContentLoaded', () => this.init());
+      }
+      this.observe();
+    }
+  }
+
+  if (!window.TextAreaAutoHeight) {
+    TextAreaAutoHeight.setup();
+    window.TextAreaAutoHeight = TextAreaAutoHeight;
+  }
+})();
 
 // # The End


### PR DESCRIPTION
## Summary
- wrap select2 widget integration in a guarded IIFE to avoid redeclaring the manager when loaded multiple times
- guard textarea auto-height initializer to skip redefinition and re-setup when script is reloaded

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928549091c48330b0d3dbc88ac712e4)