### PR TITLE
Normalize relation payload handling in Tortoise adapter

### DIFF
--- a/freeadmin/contrib/adapters/tortoise/adapter.py
+++ b/freeadmin/contrib/adapters/tortoise/adapter.py
@@ -103,6 +103,19 @@ class Adapter:
         self.system_setting_model = SystemSetting
         self.setting_value_type = SettingValueType
 
+    def _normalize_relation_value(self, field: Any, value: Any) -> Any:
+        """Return a primary-key friendly representation for relation values."""
+        related_model = getattr(field, "related_model", None)
+        pk_attr = self.get_pk_attr(related_model) if related_model else "id"
+        if isinstance(value, dict):
+            if pk_attr in value:
+                return value[pk_attr]
+            if "id" in value:
+                return value["id"]
+        if isinstance(value, str) and value.isdigit():
+            return int(value)
+        return value
+
     def normalize_import_data(self, model: type[Model], data: dict[str, Any]) -> dict[str, Any]:
         """Convert raw import values into ORM-friendly types."""
         meta = getattr(model, "_meta", None)
@@ -121,10 +134,11 @@ class Adapter:
                     fields.relational.OneToOneFieldInstance,
                 ),
             ):
+                normalized_value = self._normalize_relation_value(field, value)
                 if getattr(value, "_saved_in_db", False):
                     cleaned[name] = value
                 else:
-                    cleaned[f"{name}_id"] = value
+                    cleaned[f"{name}_id"] = normalized_value
                 continue
             if getattr(field, "enum_type", None) and isinstance(value, str):
                 if value.isdigit():
@@ -273,11 +287,20 @@ class Adapter:
         conn_name = self._resolve_connection_name()
         return in_transaction(conn_name)
 
-    async def create(self, model_cls: type[Model], **data: Any) -> Model:
+    async def create(
+        self,
+        model_cls: type[Model],
+        *,
+        include_m2m: Iterable[str] | None = None,
+        **data: Any,
+    ) -> Model:
         """Create and persist a model instance.
 
         Args:
             model_cls: Model class to instantiate.
+            include_m2m: Iterable of many-to-many field names whose values are
+                provided in ``data`` and should be assigned after instance
+                creation.
             **data: Field values for the new record.
 
         Returns:
@@ -285,8 +308,48 @@ class Adapter:
 
         This coroutine must be awaited.
         """
+        include_m2m = list(include_m2m or [])
+        m2m_values: dict[str, list[Any]] = {}
+
+        for fname in include_m2m:
+            if fname not in data:
+                continue
+            value = data.pop(fname)
+            if value is None:
+                m2m_values[fname] = []
+                continue
+            if isinstance(value, (list, tuple, set)):
+                m2m_values[fname] = list(value)
+            else:
+                m2m_values[fname] = [value]
+
         data = self.normalize_import_data(model_cls, data)
-        return await model_cls.create(**data)
+        obj = await model_cls.create(**data)
+
+        for fname, values in m2m_values.items():
+            manager = getattr(obj, fname)
+            remote_model = manager.remote_model
+            pk_attr = self.get_pk_attr(remote_model)
+
+            normalized: list[Any] = []
+            for value in values:
+                if value is None:
+                    continue
+                if isinstance(value, remote_model):
+                    normalized.append(value)
+                    continue
+                if isinstance(value, dict) and pk_attr in value:
+                    normalized.append(value[pk_attr])
+                    continue
+                if isinstance(value, str) and value.isdigit():
+                    normalized.append(int(value))
+                    continue
+                normalized.append(value)
+
+            if normalized:
+                await manager.add(*normalized)
+
+        return obj
 
     async def get(
         self,


### PR DESCRIPTION
## Summary
- normalize many-to-many payload values before attaching them to new Tortoise objects
- skip null entries and coerce dict or string identifiers before invoking many-to-many managers
- coerce foreign key payload dictionaries to primary key values during import normalization

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692893d75028833080bcf5156fd17797)