### PR TITLE
Handle missing M2M managers

### DIFF
--- a/freeadmin/contrib/adapters/tortoise/adapter.py
+++ b/freeadmin/contrib/adapters/tortoise/adapter.py
@@ -509,6 +509,8 @@ class Adapter:
 
         This coroutine must be awaited.
         """
+        if manager is None:
+            return
         await manager.clear()
 
     async def m2m_add(self, manager, objs: Iterable[Model]) -> None:
@@ -520,6 +522,8 @@ class Adapter:
 
         This coroutine must be awaited.
         """
+        if manager is None:
+            return
         await manager.add(*objs)
 
     def values(self, qs: QuerySet, *fields: str) -> QuerySet:

--- a/freeadmin/core/interface/base.py
+++ b/freeadmin/core/interface/base.py
@@ -1238,9 +1238,17 @@ class BaseModelAdmin:
         return data, m2m_ops
 
     async def m2m_clear(self, manager):
+        """Safely clear all links from the provided relation manager."""
+
+        if manager is None:
+            return
         await self.adapter.m2m_clear(manager)
 
     async def m2m_add(self, manager, objs: Iterable[Any]):
+        """Attach ``objs`` to the provided relation manager when available."""
+
+        if manager is None:
+            return
         await self.adapter.m2m_add(manager, objs)
 
     async def create(


### PR DESCRIPTION
## Summary
- add safety checks before clearing or adding many-to-many relations when no manager is available
- ensure tortoise adapter m2m helpers gracefully handle missing managers
- document admin m2m helper methods for clarity

## Testing
- python -m compileall freeadmin

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928ad22286c8330ab6282e5af101188)